### PR TITLE
Allow migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "serde"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,7 +1509,9 @@ dependencies = [
  "cw-controllers",
  "cw-storage-plus",
  "cw-utils",
+ "cw2",
  "schemars",
+ "semver",
  "serde",
  "tg-bindings",
  "tg4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "serde",
  "tg-bindings",
  "tg-bindings-test",
+ "tg-utils",
  "tg-voting-contract",
  "tg4",
  "tg4-engagement",

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1,7 +1,10 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{coin, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Env, Event, MessageInfo, Order, StdResult, Timestamp, Uint128, Empty};
-use cw2::{get_contract_version, set_contract_version};
+use cosmwasm_std::{
+    coin, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Empty, Env, Event,
+    MessageInfo, Order, StdResult, Timestamp, Uint128,
+};
+use cw2::set_contract_version;
 use cw_storage_plus::{Bound, PrimaryKey};
 use cw_utils::maybe_addr;
 use tg4::{
@@ -19,7 +22,10 @@ use crate::state::{
     PREAUTH_SLASHING, SLASHERS, WITHDRAW_ADJUSTMENT,
 };
 use tg_bindings::{request_privileges, Privilege, PrivilegeChangeMsg, TgradeMsg};
-use tg_utils::{members, validate_portion, Duration, ADMIN, HOOKS, PREAUTH_HOOKS, TOTAL, ensure_from_older_version};
+use tg_utils::{
+    ensure_from_older_version, members, validate_portion, Duration, ADMIN, HOOKS, PREAUTH_HOOKS,
+    TOTAL,
+};
 
 pub type Response = cosmwasm_std::Response<TgradeMsg>;
 pub type SubMsg = cosmwasm_std::SubMsg<TgradeMsg>;
@@ -858,7 +864,7 @@ fn list_members_by_weight(
     Ok(MemberListResponse { members: members? })
 }
 
-#[entry_point]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::new())

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1,10 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    coin, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Env, Event, MessageInfo,
-    Order, StdResult, Timestamp, Uint128,
-};
-use cw2::set_contract_version;
+use cosmwasm_std::{coin, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Env, Event, MessageInfo, Order, StdResult, Timestamp, Uint128, Empty};
+use cw2::{get_contract_version, set_contract_version};
 use cw_storage_plus::{Bound, PrimaryKey};
 use cw_utils::maybe_addr;
 use tg4::{
@@ -22,7 +19,7 @@ use crate::state::{
     PREAUTH_SLASHING, SLASHERS, WITHDRAW_ADJUSTMENT,
 };
 use tg_bindings::{request_privileges, Privilege, PrivilegeChangeMsg, TgradeMsg};
-use tg_utils::{members, validate_portion, Duration, ADMIN, HOOKS, PREAUTH_HOOKS, TOTAL};
+use tg_utils::{members, validate_portion, Duration, ADMIN, HOOKS, PREAUTH_HOOKS, TOTAL, ensure_from_older_version};
 
 pub type Response = cosmwasm_std::Response<TgradeMsg>;
 pub type SubMsg = cosmwasm_std::SubMsg<TgradeMsg>;
@@ -859,6 +856,12 @@ fn list_members_by_weight(
         .collect();
 
     Ok(MemberListResponse { members: members? })
+}
+
+#[entry_point]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new())
 }
 
 #[cfg(test)]

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -1,7 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Order, StdError, StdResult,
+    to_binary, Addr, Binary, Decimal, Deps, DepsMut, Empty, Env, MessageInfo, Order, StdError,
+    StdResult,
 };
 
 use cw2::set_contract_version;
@@ -10,7 +11,8 @@ use cw_utils::maybe_addr;
 
 use tg_bindings::TgradeMsg;
 use tg_utils::{
-    members, validate_portion, SlashMsg, HOOKS, PREAUTH_HOOKS, PREAUTH_SLASHING, SLASHERS, TOTAL,
+    ensure_from_older_version, members, validate_portion, SlashMsg, HOOKS, PREAUTH_HOOKS,
+    PREAUTH_SLASHING, SLASHERS, TOTAL,
 };
 
 use tg4::{
@@ -467,6 +469,12 @@ pub fn query_reward_function(
     .to_poe_fn()?;
 
     poe_function.rewards(stake, engagement)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new())
 }
 
 #[cfg(test)]

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, coins, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo,
-    Order, StdResult, Storage, Uint128,
+    coin, coins, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Empty, Env,
+    MessageInfo, Order, StdResult, Storage, Uint128,
 };
 
 use cw2::set_contract_version;
@@ -13,8 +13,8 @@ use tg4::{
 };
 use tg_bindings::{request_privileges, Privilege, PrivilegeChangeMsg, TgradeMsg, TgradeSudoMsg};
 use tg_utils::{
-    members, validate_portion, Duration, ADMIN, HOOKS, PREAUTH_HOOKS, PREAUTH_SLASHING, SLASHERS,
-    TOTAL,
+    ensure_from_older_version, members, validate_portion, Duration, ADMIN, HOOKS, PREAUTH_HOOKS,
+    PREAUTH_SLASHING, SLASHERS, TOTAL,
 };
 
 use crate::error::ContractError;
@@ -565,6 +565,12 @@ fn list_members_by_weight(
         .collect();
 
     Ok(MemberListResponse { members: members? })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new())
 }
 
 #[cfg(test)]

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -23,6 +23,7 @@ cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 tg-bindings = { path = "../../packages/bindings", version = "0.5.3-2" }
+tg-utils = { path = "../../packages/utils", version = "0.5.3-2" }
 tg-voting-contract = { version = "0.5.3-2", path = "../../packages/voting-contract" }
 tg4-engagement = { path = "../tg4-engagement", version = "0.5.3-2", features = ["library"] }
 thiserror = "1"

--- a/contracts/tgrade-community-pool/src/contract.rs
+++ b/contracts/tgrade-community-pool/src/contract.rs
@@ -1,9 +1,12 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, StdResult};
+use cosmwasm_std::{
+    to_binary, BankMsg, Binary, Coin, Deps, DepsMut, Empty, Env, MessageInfo, StdResult,
+};
 
 use cw2::set_contract_version;
 use tg_bindings::TgradeMsg;
+use tg_utils::ensure_from_older_version;
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, Proposal, QueryMsg};
 use crate::ContractError;
@@ -187,6 +190,12 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         ListVoters { start_after, limit } => to_binary(&list_voters(deps, start_after, limit)?),
         GroupContract {} => to_binary(&query_group_contract(deps)?),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new())
 }
 
 #[cfg(test)]

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -23,6 +23,7 @@ cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 tg-bindings = { path = "../../packages/bindings", version = "0.5.3-2" }
+tg-utils = { path = "../../packages/utils", version = "0.5.3-2" }
 tg-voting-contract = { version = "0.5.3-2", path = "../../packages/voting-contract" }
 thiserror = "1"
 

--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -10,6 +10,7 @@ use tg_bindings::{
     request_privileges, BlockParams, ConsensusParams, EvidenceParams, GovProposal, Privilege,
     PrivilegeChangeMsg, TgradeMsg, TgradeSudoMsg,
 };
+use tg_utils::ensure_from_older_version;
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, ValidatorProposal};
 use crate::ContractError;
@@ -240,6 +241,12 @@ fn privilege_change(_deps: DepsMut, change: PrivilegeChangeMsg) -> Response {
         }
         PrivilegeChangeMsg::Demoted {} => Response::new(),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new())
 }
 
 #[cfg(test)]

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -5,8 +5,8 @@ use std::convert::TryInto;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, BlockInfo, Decimal, Deps, DepsMut, Env, MessageInfo, Order, Reply,
-    StdResult, Timestamp, WasmMsg,
+    to_binary, Addr, Binary, BlockInfo, Decimal, Deps, DepsMut, Empty, Env, MessageInfo, Order,
+    Reply, StdResult, Timestamp, WasmMsg,
 };
 
 use cw2::set_contract_version;
@@ -19,7 +19,7 @@ use tg_bindings::{
     request_privileges, Ed25519Pubkey, Evidence, EvidenceType, Privilege, PrivilegeChangeMsg,
     Pubkey, TgradeMsg, TgradeSudoMsg, ValidatorDiff, ValidatorUpdate,
 };
-use tg_utils::{JailingDuration, SlashMsg, ADMIN};
+use tg_utils::{ensure_from_older_version, JailingDuration, SlashMsg, ADMIN};
 
 use crate::error::ContractError;
 use crate::msg::{
@@ -719,6 +719,12 @@ fn calculate_diff(
         ValidatorDiff { diffs },
         RewardsDistribution::UpdateMembers { add, remove },
     )
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new())
 }
 
 mod evidence {

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -18,15 +18,9 @@ pub enum TgradeQuery {
 
 impl CustomQuery for TgradeQuery {}
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, JsonSchema, Debug)]
 pub struct ValidatorVoteResponse {
     pub votes: Vec<ValidatorVote>,
-}
-
-impl Default for ValidatorVoteResponse {
-    fn default() -> Self {
-        ValidatorVoteResponse { votes: vec![] }
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -15,8 +15,10 @@ cosmwasm-std = "1.0.0-beta"
 cw-utils = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
+cw2 = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg4 = { path = "../tg4", version = "0.5.3-2" }
 tg-bindings = { path = "../bindings", version = "0.5.3-2" }
 thiserror = { version = "1.0.21" }
+semver = "1"

--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -1,6 +1,7 @@
 mod hooks;
 mod jailing;
 mod member_indexes;
+mod migrate;
 mod preauth;
 mod slashers;
 mod time;
@@ -8,6 +9,7 @@ mod time;
 pub use hooks::{HookError, Hooks};
 pub use jailing::{JailMsg, JailingDuration};
 pub use member_indexes::{members, ADMIN, HOOKS, PREAUTH_HOOKS, PREAUTH_SLASHING, SLASHERS, TOTAL};
+pub use migrate::ensure_from_older_version;
 pub use preauth::{Preauth, PreauthError};
 pub use slashers::{validate_portion, SlashMsg, SlasherError, Slashers};
 pub use time::{Duration, Expiration};

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -45,7 +45,7 @@ mod tests {
         let mut storage = MockStorage::new();
         set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
         // ensure this matches
-        ensure_from_older_version(&mut storage, "demo".into(), "0.1.2".into()).unwrap();
+        ensure_from_older_version(&mut storage, "demo", "0.1.2").unwrap();
     }
 
     #[test]
@@ -53,7 +53,7 @@ mod tests {
         let mut storage = MockStorage::new();
         set_contract_version(&mut storage, "demo", "0.4.0").unwrap();
         // ensure this matches
-        ensure_from_older_version(&mut storage, "demo".into(), "0.4.2".into()).unwrap();
+        ensure_from_older_version(&mut storage, "demo", "0.4.2").unwrap();
 
         // check the version is updated
         let stored = get_contract_version(&storage).unwrap();
@@ -66,7 +66,7 @@ mod tests {
         let mut storage = MockStorage::new();
         set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
         // ensure this matches
-        let err = ensure_from_older_version(&mut storage, "cw20-base".into(), "0.1.2".into())
+        let err = ensure_from_older_version(&mut storage, "cw20-base", "0.1.2")
             .unwrap_err();
         assert!(err.to_string().contains("cw20-base"), "{}", err);
         assert!(err.to_string().contains("demo"), "{}", err);
@@ -78,7 +78,7 @@ mod tests {
         set_contract_version(&mut storage, "demo", "0.10.2").unwrap();
         // ensure this matches
         let err =
-            ensure_from_older_version(&mut storage, "demo".into(), "0.9.7".into()).unwrap_err();
+            ensure_from_older_version(&mut storage, "demo", "0.9.7").unwrap_err();
         assert!(err.to_string().contains("0.10.2"), "{}", err);
         assert!(err.to_string().contains("0.9.7"), "{}", err);
     }

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -32,7 +32,7 @@ pub fn ensure_from_older_version(
 }
 
 fn from_semver(err: semver::Error) -> StdError {
-    StdError::generic_err(format!("Semver: {}", err.to_string()))
+    StdError::generic_err(format!("Semver: {}", err))
 }
 
 #[cfg(test)]
@@ -66,8 +66,7 @@ mod tests {
         let mut storage = MockStorage::new();
         set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
         // ensure this matches
-        let err = ensure_from_older_version(&mut storage, "cw20-base", "0.1.2")
-            .unwrap_err();
+        let err = ensure_from_older_version(&mut storage, "cw20-base", "0.1.2").unwrap_err();
         assert!(err.to_string().contains("cw20-base"), "{}", err);
         assert!(err.to_string().contains("demo"), "{}", err);
     }
@@ -77,8 +76,7 @@ mod tests {
         let mut storage = MockStorage::new();
         set_contract_version(&mut storage, "demo", "0.10.2").unwrap();
         // ensure this matches
-        let err =
-            ensure_from_older_version(&mut storage, "demo", "0.9.7").unwrap_err();
+        let err = ensure_from_older_version(&mut storage, "demo", "0.9.7").unwrap_err();
         assert!(err.to_string().contains("0.10.2"), "{}", err);
         assert!(err.to_string().contains("0.9.7"), "{}", err);
     }

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -22,7 +22,8 @@ pub fn ensure_from_older_version(
             stored.version, new_version
         );
         return Err(StdError::generic_err(msg));
-    } else if storage_version < version {
+    }
+    if storage_version < version {
         // we don't need to save anything if migrating from the same version
         set_contract_version(storage, name, new_version)?;
     }
@@ -32,4 +33,53 @@ pub fn ensure_from_older_version(
 
 fn from_semver(err: semver::Error) -> StdError {
     StdError::generic_err(format!("Semver: {}", err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::MockStorage;
+
+    #[test]
+    fn accepts_identical_version() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
+        // ensure this matches
+        ensure_from_older_version(&mut storage, "demo".into(), "0.1.2".into()).unwrap();
+    }
+
+    #[test]
+    fn accepts_and_updates_on_newer_version() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.4.0").unwrap();
+        // ensure this matches
+        ensure_from_older_version(&mut storage, "demo".into(), "0.4.2".into()).unwrap();
+
+        // check the version is updated
+        let stored = get_contract_version(&storage).unwrap();
+        assert_eq!(stored.contract, "demo".to_string());
+        assert_eq!(stored.version, "0.4.2".to_string());
+    }
+
+    #[test]
+    fn errors_on_name_mismatch() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.1.2").unwrap();
+        // ensure this matches
+        let err = ensure_from_older_version(&mut storage, "cw20-base".into(), "0.1.2".into())
+            .unwrap_err();
+        assert!(err.to_string().contains("cw20-base"), "{}", err);
+        assert!(err.to_string().contains("demo"), "{}", err);
+    }
+
+    #[test]
+    fn errors_on_older_version() {
+        let mut storage = MockStorage::new();
+        set_contract_version(&mut storage, "demo", "0.10.2").unwrap();
+        // ensure this matches
+        let err =
+            ensure_from_older_version(&mut storage, "demo".into(), "0.9.7".into()).unwrap_err();
+        assert!(err.to_string().contains("0.10.2"), "{}", err);
+        assert!(err.to_string().contains("0.9.7"), "{}", err);
+    }
 }

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -2,10 +2,14 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 use cw2::{get_contract_version, set_contract_version};
 use semver::Version;
 
-pub fn ensure_from_older_version(storage: &dyn Storage, name: &str, new_version: &str) -> StdResult<()> {
-    let version: Version = new_version.parse()?;
-    let stored = get_contract_version(deps.storage)?;
-    let storage_version: Version = stored.version.parse()?;
+pub fn ensure_from_older_version(
+    storage: &mut dyn Storage,
+    name: &str,
+    new_version: &str,
+) -> StdResult<()> {
+    let version: Version = new_version.parse().map_err(from_semver)?;
+    let stored = get_contract_version(storage)?;
+    let storage_version: Version = stored.version.parse().map_err(from_semver)?;
 
     if name != stored.contract {
         let msg = format!("Cannot migrate from {} to {}", stored.contract, name);
@@ -13,12 +17,19 @@ pub fn ensure_from_older_version(storage: &dyn Storage, name: &str, new_version:
     }
 
     if storage_version > version {
-        let msg = format!("Cannot migrate from newer version ({}) to older ({})", stored.version, new_version);
+        let msg = format!(
+            "Cannot migrate from newer version ({}) to older ({})",
+            stored.version, new_version
+        );
         return Err(StdError::generic_err(msg));
     } else if storage_version < version {
         // we don't need to save anything if migrating from the same version
-        set_contract_version(deps.storage, name, new_version)?;
+        set_contract_version(storage, name, new_version)?;
     }
 
     Ok(())
+}
+
+fn from_semver(err: semver::Error) -> StdError {
+    StdError::generic_err(format!("Semver: {}", err.to_string()))
 }

--- a/packages/utils/src/migrate.rs
+++ b/packages/utils/src/migrate.rs
@@ -1,0 +1,24 @@
+use cosmwasm_std::{StdError, StdResult, Storage};
+use cw2::{get_contract_version, set_contract_version};
+use semver::Version;
+
+pub fn ensure_from_older_version(storage: &dyn Storage, name: &str, new_version: &str) -> StdResult<()> {
+    let version: Version = new_version.parse()?;
+    let stored = get_contract_version(deps.storage)?;
+    let storage_version: Version = stored.version.parse()?;
+
+    if name != stored.contract {
+        let msg = format!("Cannot migrate from {} to {}", stored.contract, name);
+        return Err(StdError::generic_err(msg));
+    }
+
+    if storage_version > version {
+        let msg = format!("Cannot migrate from newer version ({}) to older ({})", stored.version, new_version);
+        return Err(StdError::generic_err(msg));
+    } else if storage_version < version {
+        // we don't need to save anything if migrating from the same version
+        set_contract_version(deps.storage, name, new_version)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Expose migrations in all poe-contracts.
Perform a standardised sanity check that we are migrating the same contract type and an equal or newer version