### PR TITLE
Set version: 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
+
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.5.3-2...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.5.4...HEAD)
+
+## [v0.5.4](https://github.com/confio/poe-contracts/tree/v0.5.4) (2022-01-20)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.5.3-2...v0.5.4)
+
+**Merged pull requests:**
+
+- Allow migrations [\#29](https://github.com/confio/poe-contracts/pull/29) ([ethanfrey](https://github.com/ethanfrey))
 
 ## [v0.5.3](https://github.com/confio/poe-contracts/tree/v0.5.3-2) (2022-01-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.5.3-2"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.5.3-2" }
-tg-utils = { version = "0.5.3-2", path = "../../packages/utils" }
-tg-bindings = { version = "0.5.3-2", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.5.4" }
+tg-utils = { version = "0.5.4", path = "../../packages/utils" }
+tg-bindings = { version = "0.5.4", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
 cw-multi-test = { version = "0.11.0" }
-tg-bindings-test = { version = "0.5.3-2", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.5.4", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw20 = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.5.3-2" }
-tg-utils = { path = "../../packages/utils", version = "0.5.3-2" }
-tg-bindings = { path = "../../packages/bindings", version = "0.5.3-2" }
+tg4 = { path = "../../packages/tg4", version = "0.5.4" }
+tg-utils = { path = "../../packages/utils", version = "0.5.4" }
+tg-bindings = { path = "../../packages/bindings", version = "0.5.4" }
 cosmwasm-std = "1.0.0-beta"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -47,7 +47,7 @@ cosmwasm-schema = { version = "1.0.0-beta" }
 # version's workaround for issue with cyclic dependencies during cargo publish
 # https://github.com/rust-lang/cargo/issues/4242
 tg4-engagement = { path = "../tg4-engagement", version = ">= 0.5.3-2, < 1.0.0", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.5.3-2", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.5.4", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.5.3-2" }
-tg-utils = { path = "../../packages/utils", version = "0.5.3-2" }
-tg-bindings = { path = "../../packages/bindings", version = "0.5.3-2" }
+tg4 = { path = "../../packages/tg4", version = "0.5.4" }
+tg-utils = { path = "../../packages/utils", version = "0.5.4" }
+tg-bindings = { path = "../../packages/bindings", version = "0.5.4" }
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -22,15 +22,15 @@ cw3 = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.5.3-2" }
-tg-utils = { path = "../../packages/utils", version = "0.5.3-2" }
-tg-voting-contract = { version = "0.5.3-2", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.5.3-2", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.5.4" }
+tg-utils = { path = "../../packages/utils", version = "0.5.4" }
+tg-voting-contract = { version = "0.5.4", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.5.4", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.5.3-2" }
-tg4 = { path = "../../packages/tg4", version = "0.5.3-2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.5.4" }
+tg4 = { path = "../../packages/tg4", version = "0.5.4" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/confio/poe-contracts"
@@ -25,7 +25,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta"
 cw-storage-plus = "0.11.0"
-tg-bindings = { version = "0.5.3-2", path = "../../packages/bindings" }
+tg-bindings = { version = "0.5.4", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -22,9 +22,9 @@ cw3 = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.5.3-2" }
-tg-utils = { path = "../../packages/utils", version = "0.5.3-2" }
-tg-voting-contract = { version = "0.5.3-2", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.5.4" }
+tg-utils = { path = "../../packages/utils", version = "0.5.4" }
+tg-voting-contract = { version = "0.5.4", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg-bindings-test = { version = "0.5.3-2", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.5.3-2", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.5.3-2", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.5.3-2" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.5.3-2", features = ["library"] }
+tg-bindings-test = { version = "0.5.4", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.5.4", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.5.4", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.5.4" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.5.4", features = ["library"] }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -28,9 +28,9 @@ library = []
 [dependencies]
 cw-utils = { version = "0.11.0" }
 cw2 = { version = "0.11.0" }
-tg4 = { path = "../../packages/tg4", version = "0.5.3-2" }
-tg-bindings = { version = "0.5.3-2", path = "../../packages/bindings" }
-tg-utils = { version = "0.5.3-2", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.5.4" }
+tg-bindings = { version = "0.5.4", path = "../../packages/bindings" }
+tg-utils = { version = "0.5.4", path = "../../packages/utils" }
 cw-controllers = { version = "0.11.0" }
 cw-storage-plus = { version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta" }
@@ -41,10 +41,10 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
 cw-multi-test = "0.11.0"
-tg4-engagement = { path = "../tg4-engagement", version = "0.5.3-2" }
-tg4-stake = { path = "../tg4-stake", version = "0.5.3-2" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.5.4" }
+tg4-stake = { path = "../tg4-stake", version = "0.5.4" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.5.3-2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.5.4" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.11.0"
 cw-storage-plus = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.5.3-2", path = "../../packages/bindings" }
-tg-utils = { version = "0.5.3-2", path = "../../packages/utils" }
+tg-bindings = { version = "0.5.4", path = "../../packages/bindings" }
+tg-utils = { version = "0.5.4", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
-tg-bindings-test = { version = "0.5.3-2", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.5.4", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.5.3-2", path = "../bindings" }
+tg-bindings = { version = "0.5.4", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta"
-tg-voting-contract = { path = "../voting-contract", version = "0.5.3-2" }
+tg-voting-contract = { path = "../voting-contract", version = "0.5.4" }

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.5.3-2" }
+tg-bindings = { path = "../bindings", version = "0.5.4" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.11.0"
 cw2 = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.5.3-2" }
-tg-bindings = { path = "../bindings", version = "0.5.3-2" }
+tg4 = { path = "../tg4", version = "0.5.4" }
+tg-bindings = { path = "../bindings", version = "0.5.4" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.5.3-2"
+version = "0.5.4"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -17,9 +17,9 @@ cw-storage-plus = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.5.3-2" }
-tg-bindings = { path = "../bindings", version = "0.5.3-2" }
-tg-utils = { version = "0.5.3-2", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.5.4" }
+tg-bindings = { path = "../bindings", version = "0.5.4" }
+tg-utils = { version = "0.5.4", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.5.3-2" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.5.3-2", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.5.4" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.5.4", features = ["library"] }


### PR DESCRIPTION
After #29 

Prepare to release 0.5.4, so we can tag images and deploy them to migration