### PR TITLE
valset: Add a feature to update `min_weight` and `max_validators`

### DIFF
--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -151,6 +151,11 @@ pub fn execute(
             info,
             admin.map(|admin| api.addr_validate(&admin)).transpose()?,
         )?),
+        ExecuteMsg::UpdateConfig {
+            min_weight,
+            max_validators,
+        } => execute_update_config(deps, info, min_weight, max_validators),
+
         ExecuteMsg::RegisterValidatorKey { pubkey, metadata } => {
             execute_register_validator_key(deps, env, info, pubkey, metadata)
         }
@@ -161,6 +166,31 @@ pub fn execute(
         ExecuteMsg::Unjail { operator } => execute_unjail(deps, env, info, operator),
         ExecuteMsg::Slash { addr, portion } => execute_slash(deps, env, info, addr, portion),
     }
+}
+
+fn execute_update_config(
+    deps: DepsMut,
+    info: MessageInfo,
+    min_weight: Option<u64>,
+    max_validators: Option<u32>,
+) -> Result<Response, ContractError> {
+    ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
+
+    CONFIG.update::<_, StdError>(deps.storage, |mut cfg| {
+        if let Some(min_weight) = min_weight {
+            cfg.min_weight = min_weight;
+        }
+        if let Some(max_validators) = max_validators {
+            cfg.max_validators = max_validators;
+        }
+        Ok(cfg)
+    })?;
+
+    let res = Response::new()
+        .add_attribute("action", "update_config")
+        .add_attribute("operator", &info.sender);
+
+    Ok(res)
 }
 
 fn execute_register_validator_key(

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -226,6 +226,11 @@ pub enum ExecuteMsg {
     UpdateAdmin {
         admin: Option<String>,
     },
+    /// Alter config values
+    UpdateConfig {
+        min_weight: Option<u64>,
+        max_validators: Option<u32>,
+    },
     /// Links info.sender (operator) to this Tendermint consensus key.
     /// The operator cannot re-register another key.
     /// No two operators may have the same consensus_key.

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -416,6 +416,13 @@ pub struct InstantiateResponse {
     pub rewards_contract: Addr,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {
+    pub min_weight: Option<u64>,
+    pub max_validators: Option<u32>,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/contracts/tgrade-valset/src/multitest.rs
+++ b/contracts/tgrade-valset/src/multitest.rs
@@ -3,6 +3,7 @@ mod contract;
 mod double_sign;
 mod helpers;
 mod jailing;
+mod migration;
 mod rewards_split;
 mod slashing;
 mod stake;

--- a/contracts/tgrade-valset/src/multitest.rs
+++ b/contracts/tgrade-valset/src/multitest.rs
@@ -8,3 +8,4 @@ mod rewards_split;
 mod slashing;
 mod stake;
 mod suite;
+mod update_config;

--- a/contracts/tgrade-valset/src/multitest/migration.rs
+++ b/contracts/tgrade-valset/src/multitest/migration.rs
@@ -1,0 +1,29 @@
+use super::suite::SuiteBuilder;
+use crate::msg::MigrateMsg;
+
+#[test]
+fn migration_can_alter_cfg() {
+    let mut suite = SuiteBuilder::new()
+        .with_max_validators(6)
+        .with_min_weight(3)
+        .build();
+    let admin = suite.admin().to_string();
+
+    let cfg = suite.config().unwrap();
+    assert_eq!(cfg.max_validators, 6);
+    assert_eq!(cfg.min_weight, 3);
+
+    suite
+        .migrate(
+            &admin,
+            &MigrateMsg {
+                min_weight: Some(5),
+                max_validators: Some(10),
+            },
+        )
+        .unwrap();
+
+    let cfg = suite.config().unwrap();
+    assert_eq!(cfg.max_validators, 10);
+    assert_eq!(cfg.min_weight, 5);
+}

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -556,6 +556,23 @@ impl Suite {
         )
     }
 
+    pub fn update_config(
+        &mut self,
+        executor: &str,
+        min_weight: impl Into<Option<u64>>,
+        max_validators: impl Into<Option<u32>>,
+    ) -> AnyResult<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(executor),
+            self.valset.clone(),
+            &ExecuteMsg::UpdateConfig {
+                min_weight: min_weight.into(),
+                max_validators: max_validators.into(),
+            },
+            &[],
+        )
+    }
+
     pub fn slash(
         &mut self,
         executor: &str,

--- a/contracts/tgrade-valset/src/multitest/update_config.rs
+++ b/contracts/tgrade-valset/src/multitest/update_config.rs
@@ -1,0 +1,57 @@
+use cw_controllers::AdminError;
+
+use crate::error::ContractError;
+
+use super::suite::SuiteBuilder;
+
+#[test]
+fn update_cfg() {
+    let mut suite = SuiteBuilder::new()
+        .with_max_validators(6)
+        .with_min_weight(3)
+        .build();
+    let admin = suite.admin().to_string();
+
+    let cfg = suite.config().unwrap();
+    assert_eq!(cfg.max_validators, 6);
+    assert_eq!(cfg.min_weight, 3);
+
+    suite.update_config(&admin, Some(5), Some(10)).unwrap();
+
+    let cfg = suite.config().unwrap();
+    assert_eq!(cfg.max_validators, 10);
+    assert_eq!(cfg.min_weight, 5);
+}
+
+#[test]
+fn none_values_do_not_alter_cfg() {
+    let mut suite = SuiteBuilder::new()
+        .with_max_validators(6)
+        .with_min_weight(3)
+        .build();
+    let admin = suite.admin().to_string();
+
+    let cfg = suite.config().unwrap();
+    assert_eq!(cfg.max_validators, 6);
+    assert_eq!(cfg.min_weight, 3);
+
+    suite.update_config(&admin, None, None).unwrap();
+
+    // Make sure the values haven't changed.
+    let cfg = suite.config().unwrap();
+    assert_eq!(cfg.max_validators, 6);
+    assert_eq!(cfg.min_weight, 3);
+}
+
+#[test]
+fn non_admin_cannot_update_cfg() {
+    let mut suite = SuiteBuilder::new().build();
+
+    let err = suite
+        .update_config("random fella", Some(5), Some(10))
+        .unwrap_err();
+    assert_eq!(
+        ContractError::AdminError(AdminError::NotAdmin {}),
+        err.downcast().unwrap(),
+    );
+}


### PR DESCRIPTION
Closes #28 

Two ways to update `min_weight` and `max_validators` - by migration or by using an `ExecuteMsg` entrypoint.