### PR TITLE
Rename API to points and rewards

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,65 @@
+# Migrating
+
+This guide lists API changes between releases of *PoE* contracts.
+
+## 0.6.0-beta1 -> 0.6.0-beta2
+
+### tg4-engagement
+
+Messages changes:
+
+* `distribute_funds` message renamed to `distribute_rewards`
+* `withdraw_funds` message renamed to `withdraw_rewards`
+* `total_weight` query renamed to `total_points`
+* `list_members_by_weight` query renamed to `list_members_by_points`
+* `withdrawable_funds` query renamed to `withdrawable_rewards`
+* `distributed_funds` query renamed to `distributed_rewards`
+* `undistributed_funds` query renamed to `undistributed_rewards`
+
+State changes:
+
+* `points_per_weight` field on `distribution` renamed to `shares_per_point`
+* `points_leftover` field on `distribution` renamed to `shares_leftover`
+* `points_correction` field on `withdraw_adjustment` map items renamed to `shares_correction`
+* `withdrawn_funds` field on `withdraw_adjustment` map items renamed to `withdrawn_rewards`
+
+### tg4-mixer
+
+Messages changes:
+
+* `total_weight` query renamed to `total_points`
+* `list_members_by_weight` query renamed to `list_members_by_points`
+* `reward_function` query renamed to `mixer_function`
+* `reward` field on response to `mixer_function` (`reward_function` previously)
+  renamed to `points`
+
+### tg4-stake
+
+Messages changes:
+
+* `tokens_per_weight` field on instantiate message renamed to `tokens_per_point`
+* `total_weight` query renamed to `total_points`
+* `list_members_by_weight` query renamed to `list_members_by_points`
+* `weight` field on response to `total_points` (`total_weight` previously)
+  renamed to `points`
+
+State changes:
+
+* `tokens_per_weight` field on `config` item renamed to `tokens_per_point`
+
+### tgrade-community-pool
+
+Messages changes:
+
+* `distribute_funds` message renamed to `distribute_rewards`
+
+### tgrade-valset
+
+Messages changes:
+
+* `min_weight` field on instantiate message renamed to `min_points`
+
+State changes:
+
+* `min_weight` field on `config` item renamed to `min_points`
+

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,7 +2,7 @@
 
 This guide lists API changes between releases of *PoE* contracts.
 
-## 0.6.0-beta1 -> 0.6.0-beta2
+## 0.6.0-beta1 -> 0.6.0-rc1
 
 ### tg4-engagement
 

--- a/contracts/tg4-engagement/examples/schema.rs
+++ b/contracts/tg4-engagement/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 
-pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalWeightResponse};
+pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalPointsResponse};
 pub use tg4_engagement::msg::{
     DelegatedResponse, ExecuteMsg, FundsResponse, InstantiateMsg, PreauthResponse, QueryMsg,
     SudoMsg,
@@ -21,7 +21,7 @@ fn main() {
     export_schema(&schema_for!(AdminResponse), &out_dir);
     export_schema(&schema_for!(MemberListResponse), &out_dir);
     export_schema(&schema_for!(MemberResponse), &out_dir);
-    export_schema(&schema_for!(TotalWeightResponse), &out_dir);
+    export_schema(&schema_for!(TotalPointsResponse), &out_dir);
     export_schema(&schema_for!(PreauthResponse), &out_dir);
     export_schema(&schema_for!(SudoMsg), &out_dir);
     export_schema(&schema_for!(FundsResponse), &out_dir);

--- a/contracts/tg4-engagement/examples/schema.rs
+++ b/contracts/tg4-engagement/examples/schema.rs
@@ -5,7 +5,7 @@ use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, s
 
 pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalPointsResponse};
 pub use tg4_engagement::msg::{
-    DelegatedResponse, ExecuteMsg, FundsResponse, InstantiateMsg, PreauthResponse, QueryMsg,
+    DelegatedResponse, ExecuteMsg, InstantiateMsg, PreauthResponse, QueryMsg, RewardsResponse,
     SudoMsg,
 };
 
@@ -24,6 +24,6 @@ fn main() {
     export_schema(&schema_for!(TotalPointsResponse), &out_dir);
     export_schema(&schema_for!(PreauthResponse), &out_dir);
     export_schema(&schema_for!(SudoMsg), &out_dir);
-    export_schema(&schema_for!(FundsResponse), &out_dir);
+    export_schema(&schema_for!(RewardsResponse), &out_dir);
     export_schema(&schema_for!(DelegatedResponse), &out_dir);
 }

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -699,7 +699,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             at_height: height,
         } => to_binary(&query_member(deps, addr, height)?),
         ListMembers { start_after, limit } => to_binary(&list_members(deps, start_after, limit)?),
-        ListMembersByWeight { start_after, limit } => {
+        ListMembersByPoints { start_after, limit } => {
             to_binary(&list_members_by_weight(deps, start_after, limit)?)
         }
         TotalPoints {} => to_binary(&query_total_weight(deps)?),

--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -39,17 +39,17 @@ pub enum ExecuteMsg {
     AddHook { addr: String },
     /// Remove a hook. Must be called by Admin
     RemoveHook { addr: String },
-    /// Distributes funds sent with this message, and all funds transferred since last call of this
-    /// to members, proportionally to their weights. Funds are not immediately send to members, but
+    /// Distributes rewards sent with this message, and all rewards transferred since last call of this
+    /// to members, proportionally to their weights. Rewards are not immediately send to members, but
     /// assigned to them for later withdrawal (see: `ExecuteMsg::WithdrawFunds`)
-    DistributeFunds {
-        /// Original source of funds, informational. If present overwrites "sender" field on
+    DistributeRewards {
+        /// Original source of rewards, informational. If present overwrites "sender" field on
         /// propagated event.
         sender: Option<String>,
     },
-    /// Withdraws funds which were previously distributed and assigned to sender.
-    WithdrawFunds {
-        /// Account which funds assigned too should be withdrawn, `sender` by default. `sender` has
+    /// Withdraws rewards which were previously distributed and assigned to sender.
+    WithdrawRewards {
+        /// Account which rewards assigned too should be withdrawn, `sender` by default. `sender` has
         /// to be eligible for withdrawal from `owner` address to perform this call (`owner` has to
         /// call `DelegateWithdrawal { delegated: sender }` before)
         owner: Option<String>,
@@ -77,8 +77,8 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     /// Return AdminResponse
     Admin {},
-    /// Return TotalWeightResponse
-    TotalWeight {},
+    /// Return TotalPointsResponse
+    TotalPoints {},
     /// Returns MemberListResponse
     ListMembers {
         start_after: Option<String>,
@@ -98,16 +98,16 @@ pub enum QueryMsg {
     Hooks {},
     /// Return the current number of preauths. Returns PreauthResponse.
     Preauths {},
-    /// Return how much funds are assigned for withdrawal to given address. Returns
-    /// `FundsResponse`.
-    WithdrawableFunds { owner: String },
-    /// Return how much funds were distributed in total by this contract. Returns
-    /// `FundsResponse`.
-    DistributedFunds {},
+    /// Return how much rewards are assigned for withdrawal to given address. Returns
+    /// `RewardsResponse`.
+    WithdrawableRewards { owner: String },
+    /// Return how much rewards were distributed in total by this contract. Returns
+    /// `RewardsResponse`.
+    DistributedRewards {},
     /// Return how much funds were send to this contract since last `ExecuteMsg::DistribtueFunds`,
-    /// and wait for distribution. Returns `FundsResponse`.
-    UndistributedFunds {},
-    /// Returns address allowed for withdrawal funds assigned to owner. Returns `DelegatedResponse`
+    /// and wait for distribution. Returns `RewardsResponse`.
+    UndistributedRewards {},
+    /// Returns address allowed for withdrawal funds assigned to owner. Returns `DelegateResponse`
     Delegated { owner: String },
     /// Returns information about the halflife, including the duration in seconds, the last
     /// and the next occurence.
@@ -151,8 +151,8 @@ pub struct PreauthResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct FundsResponse {
-    pub funds: Coin,
+pub struct RewardsResponse {
+    pub rewards: Coin,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn deserialize_json_to_sudo_msg() {
-        let message = r#"{"update_member": {"addr": "xxx", "weight": 123}}"#;
+        let message = r#"{"update_member": {"addr": "xxx", "points": 123}}"#;
         assert_eq!(
             SudoMsg::UpdateMember(Member {
                 addr: "xxx".to_string(),

--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -193,7 +193,7 @@ mod tests {
         assert_eq!(
             SudoMsg::UpdateMember(Member {
                 addr: "xxx".to_string(),
-                weight: 123
+                points: 123
             }),
             cosmwasm_std::from_slice::<SudoMsg>(message.as_bytes()).unwrap()
         );

--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -85,7 +85,7 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     /// Returns MemberListResponse, sorted by weight descending
-    ListMembersByWeight {
+    ListMembersByPoints {
         start_after: Option<Member>,
         limit: Option<u32>,
     },

--- a/contracts/tg4-engagement/src/multitest.rs
+++ b/contracts/tg4-engagement/src/multitest.rs
@@ -10,7 +10,7 @@ use tg_utils::{Duration, PreauthError};
 fn member(addr: &str, weight: u64) -> Member {
     Member {
         addr: addr.to_owned(),
-        weight,
+        points: weight,
     }
 }
 

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -162,7 +162,7 @@ impl Suite {
         self.app.execute_contract(
             Addr::unchecked(executor),
             self.contract.clone(),
-            &ExecuteMsg::DistributeFunds {
+            &ExecuteMsg::DistributeRewards {
                 sender: sender.into().map(str::to_owned),
             },
             funds,
@@ -178,7 +178,7 @@ impl Suite {
         self.app.execute_contract(
             Addr::unchecked(executor),
             self.contract.clone(),
-            &ExecuteMsg::WithdrawFunds {
+            &ExecuteMsg::WithdrawRewards {
                 owner: owner.into().map(str::to_owned),
                 receiver: receiver.into().map(str::to_owned),
             },
@@ -283,29 +283,29 @@ impl Suite {
     }
 
     pub fn withdrawable_funds(&self, owner: &str) -> Result<Coin, ContractError> {
-        let resp: FundsResponse = self.app.wrap().query_wasm_smart(
+        let resp: RewardsResponse = self.app.wrap().query_wasm_smart(
             self.contract.clone(),
-            &QueryMsg::WithdrawableFunds {
+            &QueryMsg::WithdrawableRewards {
                 owner: owner.to_owned(),
             },
         )?;
-        Ok(resp.funds)
+        Ok(resp.rewards)
     }
 
     pub fn distributed_funds(&self) -> Result<Coin, ContractError> {
-        let resp: FundsResponse = self
+        let resp: RewardsResponse = self
             .app
             .wrap()
-            .query_wasm_smart(self.contract.clone(), &QueryMsg::DistributedFunds {})?;
-        Ok(resp.funds)
+            .query_wasm_smart(self.contract.clone(), &QueryMsg::DistributedRewards {})?;
+        Ok(resp.rewards)
     }
 
     pub fn undistributed_funds(&self) -> Result<Coin, ContractError> {
-        let resp: FundsResponse = self
+        let resp: RewardsResponse = self
             .app
             .wrap()
-            .query_wasm_smart(self.contract.clone(), &QueryMsg::UndistributedFunds {})?;
-        Ok(resp.funds)
+            .query_wasm_smart(self.contract.clone(), &QueryMsg::UndistributedRewards {})?;
+        Ok(resp.rewards)
     }
 
     pub fn delegated(&self, owner: &str) -> Result<Addr, ContractError> {

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -25,7 +25,7 @@ pub fn expected_members(members: Vec<(&str, u64)>) -> Vec<Member> {
         .into_iter()
         .map(|(addr, weight)| Member {
             addr: addr.to_owned(),
-            weight,
+            points: weight,
         })
         .collect()
 }
@@ -45,7 +45,7 @@ impl SuiteBuilder {
     pub fn with_member(mut self, addr: &str, weight: u64) -> Self {
         self.members.push(Member {
             addr: addr.to_owned(),
-            weight,
+            points: weight,
         });
         self
     }
@@ -211,7 +211,7 @@ impl Suite {
             .iter()
             .map(|(addr, weight)| Member {
                 addr: (*addr).to_owned(),
-                weight: *weight,
+                points: *weight,
             })
             .collect();
 

--- a/contracts/tg4-engagement/src/state.rs
+++ b/contracts/tg4-engagement/src/state.rs
@@ -33,7 +33,7 @@ impl Halflife {
 /// `32, to have those 32 bits, but it reduces how much tokens may be handled by this contract
 /// (it is now 96-bit integer instead of 128). In original ERC2222 it is handled by 256-bit
 /// calculations, but I256 is missing and it is required for this.
-pub const POINTS_SHIFT: u8 = 32;
+pub const SHARES_SHIFT: u8 = 32;
 
 pub const HALFLIFE: Item<Halflife> = Item::new("halflife");
 
@@ -41,22 +41,22 @@ pub const HALFLIFE: Item<Halflife> = Item::new("halflife");
 pub struct Distribution {
     /// Tokens can be distributed by this denom.
     pub denom: String,
-    /// How much points is single point of weight worth at this point.
-    pub points_per_weight: Uint128,
-    /// Points which were not fully distributed on previous distributions, and should be redistributed
-    pub points_leftover: u64,
-    /// Total funds distributed by this contract.
+    /// How many shares is single point worth
+    pub shares_per_point: Uint128,
+    /// Shares which were not fully distributed on previous distributions, and should be redistributed
+    pub shares_leftover: u64,
+    /// Total rewards distributed by this contract.
     pub distributed_total: Uint128,
-    /// Total funds not yet withdrawn.
+    /// Total rewards not yet withdrawn.
     pub withdrawable_total: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct WithdrawAdjustment {
     /// How much points should be added/removed from calculated funds while withdrawal.
-    pub points_correction: Int128,
+    pub shares_correction: Int128,
     /// How much funds addresses already withdrawn.
-    pub withdrawn_funds: Uint128,
+    pub withdrawn_rewards: Uint128,
     /// User delegated for funds withdrawal
     pub delegated: Addr,
 }

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -7,7 +7,7 @@ use cosmwasm_vm::from_slice;
 use cosmwasm_vm::testing::{mock_env, mock_instance, query};
 
 use tg4_mixer::msg::PoEFunctionType::{AlgebraicSigmoid, GeometricMean, Sigmoid, SigmoidSqrt};
-use tg4_mixer::msg::{QueryMsg, RewardFunctionResponse};
+use tg4_mixer::msg::{MixerFunctionResponse, QueryMsg};
 
 // Output of cargo wasm
 static WASM: &[u8] =
@@ -62,7 +62,7 @@ fn main() {
             86607900000,
         ),
     ] {
-        let benchmark_msg = QueryMsg::RewardFunction {
+        let benchmark_msg = QueryMsg::MixerFunction {
             stake: Uint64::new(STAKE),
             engagement: Uint64::new(ENGAGEMENT),
             poe_function: Some(poe_fn),
@@ -70,17 +70,17 @@ fn main() {
 
         let gas_before = deps.get_gas_left();
         let raw = query(&mut deps, mock_env(), benchmark_msg).unwrap();
-        let res: RewardFunctionResponse = from_slice(&raw, DESERIALIZATION_LIMIT).unwrap();
+        let res: MixerFunctionResponse = from_slice(&raw, DESERIALIZATION_LIMIT).unwrap();
         let gas_used = gas_before - deps.get_gas_left();
         let sdk_gas = gas_used / GAS_MULTIPLIER;
 
         println!(
             "{:>16}({}, {}) = {:>5} ({:>3} SDK gas)",
-            poe_fn_name, STAKE, ENGAGEMENT, res.reward, sdk_gas
+            poe_fn_name, STAKE, ENGAGEMENT, res.points, sdk_gas
         );
 
         assert_eq!(
-            RewardFunctionResponse { reward: result },
+            MixerFunctionResponse { points: result },
             res,
             "{} result",
             poe_fn_name

--- a/contracts/tg4-mixer/examples/schema.rs
+++ b/contracts/tg4-mixer/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 
-pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalWeightResponse};
+pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalPointsResponse};
 pub use tg4_mixer::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 fn main() {
@@ -18,5 +18,5 @@ fn main() {
     export_schema(&schema_for!(AdminResponse), &out_dir);
     export_schema(&schema_for!(MemberListResponse), &out_dir);
     export_schema(&schema_for!(MemberResponse), &out_dir);
-    export_schema(&schema_for!(TotalWeightResponse), &out_dir);
+    export_schema(&schema_for!(TotalPointsResponse), &out_dir);
 }

--- a/contracts/tg4-mixer/src/error.rs
+++ b/contracts/tg4-mixer/src/error.rs
@@ -26,14 +26,14 @@ pub enum ContractError {
     #[error("Contract {0} doesn't fulfill the tg4 interface")]
     NotTg4(String),
 
-    #[error("Overflow when multiplying group weights - the product must be less than 10^18")]
-    WeightOverflow {},
+    #[error("Overflow when multiplying group points - the product must be less than 10^18")]
+    PointsOverflow {},
 
     #[error("Overflow when computing: {0}")]
     ComputationOverflow(&'static str),
 
-    #[error("Overflow when computing rewards - the result cannot be represented as u64")]
-    RewardOverflow {},
+    #[error("Overflow when mixing input points - the result cannot be represented as u64")]
+    MixerOverflow {},
 
     #[error("The parameter '{0}' is out of range: {1}")]
     ParameterRange(&'static str, String),

--- a/contracts/tg4-mixer/src/msg.rs
+++ b/contracts/tg4-mixer/src/msg.rs
@@ -90,15 +90,15 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    /// Return TotalWeightResponse
-    TotalWeight {},
+    /// Return TotalPointsResponse
+    TotalPoints {},
     /// Returns MemberListResponse
     ListMembers {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    /// Returns MemberListResponse, sorted by weight descending
-    ListMembersByWeight {
+    /// Returns MemberListResponse, sorted by points descending
+    ListMembersByPoints {
         start_after: Option<Member>,
         limit: Option<u32>,
     },
@@ -113,9 +113,9 @@ pub enum QueryMsg {
     Groups {},
     /// Return the current number of preauths. Returns PreauthResponse.
     Preauths {},
-    /// Rewards of a PoE function (used for benchmarking).
-    /// Returns RewardsResponse.
-    RewardFunction {
+    /// Points assigned by a PoE mixer function (used for benchmarking).
+    /// Returns MixerFunctionResponse.
+    MixerFunction {
         stake: Uint64,
         engagement: Uint64,
         poe_function: Option<PoEFunctionType>,
@@ -139,6 +139,6 @@ pub struct PreauthResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct RewardFunctionResponse {
-    pub reward: u64,
+pub struct MixerFunctionResponse {
+    pub points: u64,
 }

--- a/contracts/tg4-stake/examples/schema.rs
+++ b/contracts/tg4-stake/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, schema_for};
 
-pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalWeightResponse};
+pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalPointsResponse};
 pub use tg4_stake::msg::{
     ClaimsResponse, ExecuteMsg, InstantiateMsg, PreauthResponse, QueryMsg, StakedResponse,
     UnbondingPeriodResponse,
@@ -21,7 +21,7 @@ fn main() {
     export_schema(&schema_for!(AdminResponse), &out_dir);
     export_schema(&schema_for!(MemberListResponse), &out_dir);
     export_schema(&schema_for!(MemberResponse), &out_dir);
-    export_schema(&schema_for!(TotalWeightResponse), &out_dir);
+    export_schema(&schema_for!(TotalPointsResponse), &out_dir);
     export_schema(&schema_for!(ClaimsResponse), &out_dir);
     export_schema(&schema_for!(UnbondingPeriodResponse), &out_dir);
     export_schema(&schema_for!(StakedResponse), &out_dir);

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -511,7 +511,7 @@ fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<Memb
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
     }?;
-    Ok(MemberResponse { weight })
+    Ok(MemberResponse { points: weight })
 }
 
 // settings for pagination
@@ -534,7 +534,7 @@ fn list_members(
             let (addr, weight) = item?;
             Ok(Member {
                 addr: addr.into(),
-                weight,
+                points: weight,
             })
         })
         .collect();
@@ -548,7 +548,7 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|m| Bound::exclusive((m.weight, m.addr.as_str()).joined_key()));
+    let start = start_after.map(|m| Bound::exclusive((m.points, m.addr.as_str()).joined_key()));
 
     let members: StdResult<Vec<_>> = members()
         .idx
@@ -559,7 +559,7 @@ fn list_members_by_weight(
             let (addr, weight) = item?;
             Ok(Member {
                 addr: addr.into(),
-                weight,
+                points: weight,
             })
         })
         .collect();
@@ -697,7 +697,7 @@ mod tests {
     fn get_member(deps: Deps, addr: String, at_height: Option<u64>) -> Option<u64> {
         let raw = query(deps, mock_env(), QueryMsg::Member { addr, at_height }).unwrap();
         let res: MemberResponse = from_slice(&raw).unwrap();
-        res.weight
+        res.points
     }
 
     // this tests the member queries
@@ -789,13 +789,13 @@ mod tests {
         bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
 
         let member1 = query_member(deps.as_ref(), USER1.into(), None).unwrap();
-        assert_eq!(member1.weight, Some(12));
+        assert_eq!(member1.points, Some(12));
 
         let member2 = query_member(deps.as_ref(), USER2.into(), None).unwrap();
-        assert_eq!(member2.weight, Some(7));
+        assert_eq!(member2.points, Some(7));
 
         let member3 = query_member(deps.as_ref(), USER3.into(), None).unwrap();
-        assert_eq!(member3.weight, None);
+        assert_eq!(member3.points, None);
 
         let members = list_members(deps.as_ref(), None, None).unwrap().members;
         assert_eq!(members.len(), 2);
@@ -805,11 +805,11 @@ mod tests {
             vec![
                 Member {
                     addr: USER1.into(),
-                    weight: 12
+                    points: 12
                 },
                 Member {
                     addr: USER2.into(),
-                    weight: 7
+                    points: 7
                 },
             ]
         );
@@ -822,7 +822,7 @@ mod tests {
             members,
             vec![Member {
                 addr: USER1.into(),
-                weight: 12
+                points: 12
             },]
         );
 
@@ -837,7 +837,7 @@ mod tests {
             members,
             vec![Member {
                 addr: USER2.into(),
-                weight: 7
+                points: 7
             },]
         );
 
@@ -866,15 +866,15 @@ mod tests {
             vec![
                 Member {
                     addr: USER1.into(),
-                    weight: 11
+                    points: 11
                 },
                 Member {
                     addr: USER2.into(),
-                    weight: 6
+                    points: 6
                 },
                 Member {
                     addr: USER3.into(),
-                    weight: 5
+                    points: 5
                 }
             ]
         );
@@ -889,7 +889,7 @@ mod tests {
             members,
             vec![Member {
                 addr: USER1.into(),
-                weight: 11
+                points: 11
             },]
         );
 
@@ -906,11 +906,11 @@ mod tests {
             vec![
                 Member {
                     addr: USER2.into(),
-                    weight: 6
+                    points: 6
                 },
                 Member {
                     addr: USER3.into(),
-                    weight: 5
+                    points: 5
                 }
             ]
         );

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -14,7 +14,7 @@ const fn default_auto_return_limit() -> u64 {
 pub struct InstantiateMsg {
     /// denom of the token to stake
     pub denom: String,
-    pub tokens_per_weight: Uint128,
+    pub tokens_per_point: Uint128,
     pub min_bond: Uint128,
     /// unbounding period in seconds
     pub unbonding_period: u64,
@@ -83,15 +83,16 @@ pub enum QueryMsg {
 
     /// Return AdminResponse
     Admin {},
-    /// Return TotalWeightResponse
-    TotalWeight {},
+    /// Return TotalPointsResponse. This is the amount of tokens bonded divided by
+    /// tokens_per_point.
+    TotalPoints {},
     /// Returns MemberListResponse
     ListMembers {
         start_after: Option<String>,
         limit: Option<u32>,
     },
     /// Returns MemberListResponse, sorted by weight descending.
-    ListMembersByWeight {
+    ListMembersByPoints {
         start_after: Option<Member>,
         limit: Option<u32>,
     },
@@ -133,8 +134,8 @@ pub struct ClaimsResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct TotalWeightResponse {
-    pub weight: u64,
+pub struct TotalPointsResponse {
+    pub points: u64,
     pub denom: String,
 }
 

--- a/contracts/tg4-stake/src/state.rs
+++ b/contracts/tg4-stake/src/state.rs
@@ -15,7 +15,7 @@ pub fn claims() -> Claims<'static> {
 pub struct Config {
     /// denom of the token to stake
     pub denom: String,
-    pub tokens_per_weight: Uint128,
+    pub tokens_per_point: Uint128,
     pub min_bond: Uint128,
     /// time in seconds
     pub unbonding_period: Duration,

--- a/contracts/tgrade-community-pool/src/contract.rs
+++ b/contracts/tgrade-community-pool/src/contract.rs
@@ -58,7 +58,7 @@ pub fn execute(
             execute_close::<Proposal>(deps, env, info, proposal_id).map_err(ContractError::from)
         }
         ExecuteMsg::WithdrawEngagementRewards {} => execute_withdraw_engagement_rewards(deps, info),
-        ExecuteMsg::DistributeFunds {} => Ok(Response::new()),
+        ExecuteMsg::DistributeRewards {} => Ok(Response::new()),
     }
 }
 

--- a/contracts/tgrade-community-pool/src/contract.rs
+++ b/contracts/tgrade-community-pool/src/contract.rs
@@ -131,7 +131,7 @@ pub fn execute_withdraw_engagement_rewards(
     let group_contract = VOTING_CONFIG.load(deps.storage)?.group_contract;
 
     let msg = group_contract.encode_raw_msg(to_binary(
-        &tg4_engagement::msg::ExecuteMsg::WithdrawFunds {
+        &tg4_engagement::msg::ExecuteMsg::WithdrawRewards {
             owner: None,
             receiver: None,
         },

--- a/contracts/tgrade-community-pool/src/msg.rs
+++ b/contracts/tgrade-community-pool/src/msg.rs
@@ -53,7 +53,7 @@ pub enum ExecuteMsg {
     WithdrawEngagementRewards {},
     /// Message comming from valset on funds distribution, just takes funds
     /// send with message and does nothing
-    DistributeFunds {},
+    DistributeRewards {},
 }
 
 // We can also add this as a cw3 extension

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -204,7 +204,7 @@ impl Suite {
         self.app.execute_contract(
             self.owner.clone(),
             self.group_contract.clone(),
-            &tg4_engagement::ExecuteMsg::DistributeFunds { sender: None },
+            &tg4_engagement::ExecuteMsg::DistributeRewards { sender: None },
             &[coin(amount, self.group_token.clone())],
         )
     }

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -52,7 +52,7 @@ impl SuiteBuilder {
     pub fn with_group_member(mut self, addr: &str, weight: u64) -> Self {
         self.group_members.push(Member {
             addr: addr.to_owned(),
-            weight,
+            points: weight,
         });
         self
     }
@@ -147,7 +147,7 @@ impl SuiteBuilder {
                     remove: vec![],
                     add: vec![Member {
                         addr: contract.to_string(),
-                        weight: self.contract_weight,
+                        points: self.contract_weight,
                     }],
                 },
                 &[],

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -237,7 +237,7 @@ impl Suite {
         self.app.execute_contract(
             self.owner.clone(),
             self.contract.clone(),
-            &ExecuteMsg::DistributeFunds {},
+            &ExecuteMsg::DistributeRewards {},
             &[coin(amount, self.group_token.clone())],
         )
     }

--- a/contracts/tgrade-validator-voting/src/multitest/suite.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/suite.rs
@@ -60,7 +60,7 @@ impl SuiteBuilder {
     pub fn with_group_member(mut self, addr: &str, weight: u64) -> Self {
         self.group_members.push(Member {
             addr: addr.to_owned(),
-            weight,
+            points: weight,
         });
         self
     }

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -708,7 +708,7 @@ fn calculate_validators(
 
         let filtered: Vec<_> = batch
             .into_iter()
-            .filter(|m| m.weight >= min_weight)
+            .filter(|m| m.points >= min_weight)
             .filter_map(|m| -> Option<StdResult<_>> {
                 // why do we allow Addr::unchecked here?
                 // all valid keys for `operators()` are already validated before insertion
@@ -740,7 +740,7 @@ fn calculate_validators(
                     Ok(ValidatorInfo {
                         operator: m_addr,
                         validator_pubkey: op.pubkey.into(),
-                        power: m.weight * scaling,
+                        power: m.points * scaling,
                     })
                 })
             })
@@ -787,7 +787,7 @@ fn calculate_diff(
             };
             let member = Member {
                 addr: vi.operator.to_string(),
-                weight: vi.power,
+                points: vi.power,
             };
 
             (update, member)
@@ -1001,7 +1001,7 @@ mod test {
             .into_iter()
             .map(|(addr, weight)| Member {
                 addr: addr.to_owned(),
-                weight,
+                points: weight,
             })
             .collect()
     }

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -65,7 +65,7 @@ pub fn instantiate(
 
     let cfg = Config {
         membership,
-        min_weight: msg.min_weight,
+        min_points: msg.min_points,
         max_validators: msg.max_validators,
         scaling: msg.scaling,
         epoch_reward: msg.epoch_reward,
@@ -153,7 +153,7 @@ pub fn execute(
             admin.map(|admin| api.addr_validate(&admin)).transpose()?,
         )?),
         ExecuteMsg::UpdateConfig {
-            min_weight,
+            min_points: min_weight,
             max_validators,
         } => execute_update_config(deps, info, min_weight, max_validators),
 
@@ -183,7 +183,7 @@ fn execute_update_config(
 
     CONFIG.update::<_, StdError>(deps.storage, |mut cfg| {
         if let Some(min_weight) = min_weight {
-            cfg.min_weight = min_weight;
+            cfg.min_points = min_weight;
         }
         if let Some(max_validators) = max_validators {
             cfg.max_validators = max_validators;
@@ -693,7 +693,7 @@ fn calculate_validators(
 ) -> Result<(Vec<ValidatorInfo>, Vec<Addr>), ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
 
-    let min_weight = max(cfg.min_weight, 1);
+    let min_weight = max(cfg.min_points, 1);
     let scaling: u64 = cfg.scaling.unwrap_or(1).into();
 
     // get all validators from the contract, filtered
@@ -828,8 +828,8 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     CONFIG.update::<_, StdError>(deps.storage, |mut cfg| {
-        if let Some(min_weight) = msg.min_weight {
-            cfg.min_weight = min_weight;
+        if let Some(min_weight) = msg.min_points {
+            cfg.min_points = min_weight;
         }
         if let Some(max_validators) = msg.max_validators {
             cfg.max_validators = max_validators;

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -700,7 +700,7 @@ fn calculate_validators(
     let mut validators = vec![];
     let mut batch = cfg
         .membership
-        .list_members_by_weight(&deps.querier, None, QUERY_LIMIT)?;
+        .list_members_by_points(&deps.querier, None, QUERY_LIMIT)?;
     let mut auto_unjail = vec![];
 
     while !batch.is_empty() && validators.len() < cfg.max_validators as usize {
@@ -751,7 +751,7 @@ fn calculate_validators(
         // and get the next page
         batch = cfg
             .membership
-            .list_members_by_weight(&deps.querier, last, QUERY_LIMIT)?;
+            .list_members_by_points(&deps.querier, last, QUERY_LIMIT)?;
     }
 
     Ok((validators, auto_unjail))

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -18,11 +18,11 @@ pub struct InstantiateMsg {
     pub admin: Option<String>,
     /// Address of a cw4 contract with the raw membership used to feed the validator set
     pub membership: String,
-    /// Minimum weight needed by an address in `membership` to be considered for the validator set.
-    /// 0-weight members are always filtered out.
+    /// Minimum points needed by an address in `membership` to be considered for the validator set.
+    /// 0-point members are always filtered out.
     /// TODO: if we allow sub-1 scaling factors, determine if this is pre-/post- scaling
-    /// (use weight for cw4, power for Tendermint)
-    pub min_weight: u64,
+    /// (use points for cw4, power for Tendermint)
+    pub min_points: u64,
     /// The maximum number of validators that can be included in the Tendermint validator set.
     /// If there are more validators than slots, we select the top N by membership weight
     /// descending. (In case of ties at the last slot, select by "first" Tendermint pubkey,
@@ -151,7 +151,7 @@ impl InstantiateMsg {
         if self.epoch_length == 0 {
             return Err(ContractError::InvalidEpoch {});
         }
-        if self.min_weight == 0 {
+        if self.min_points == 0 {
             return Err(ContractError::InvalidMinWeight {});
         }
         if self.max_validators == 0 {
@@ -228,7 +228,7 @@ pub enum ExecuteMsg {
     },
     /// Alter config values
     UpdateConfig {
-        min_weight: Option<u64>,
+        min_points: Option<u64>,
         max_validators: Option<u32>,
     },
     /// Links info.sender (operator) to this Tendermint consensus key.
@@ -405,7 +405,7 @@ pub struct ListValidatorSlashingResponse {
 pub enum DistributionMsg {
     /// Message sent to `distribution_contract` with funds which are part of the reward to be split
     /// between engaged operators
-    DistributeFunds {},
+    DistributeRewards {},
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -423,7 +423,7 @@ pub enum RewardsDistribution {
         remove: Vec<String>,
         add: Vec<Member>,
     },
-    DistributeFunds {},
+    DistributeRewards {},
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -435,7 +435,7 @@ pub struct InstantiateResponse {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {
-    pub min_weight: Option<u64>,
+    pub min_points: Option<u64>,
     pub max_validators: Option<u32>,
 }
 
@@ -458,7 +458,7 @@ mod test {
         let proper = InstantiateMsg {
             admin: None,
             membership: "contract-addr".into(),
-            min_weight: 5,
+            min_points: 5,
             max_validators: 20,
             epoch_length: 5000,
             epoch_reward: coin(7777, "foobar"),
@@ -485,7 +485,7 @@ mod test {
 
         // fails on 0 min weight
         let mut invalid = proper.clone();
-        invalid.min_weight = 0;
+        invalid.min_points = 0;
         let err = invalid.validate().unwrap_err();
         assert_eq!(err, ContractError::InvalidMinWeight {});
 

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -16,7 +16,7 @@ fn initialization() {
         .with_operators(&members)
         .with_epoch_reward(coin(100, "eth"))
         .with_max_validators(10)
-        .with_min_weight(5)
+        .with_min_points(5)
         .with_epoch_length(3600)
         .build();
 
@@ -27,7 +27,7 @@ fn initialization() {
             // This one it is basically assumed is set correctly. Other tests tests if behavior
             // of relation between those contract is correct
             membership: config.membership.clone(),
-            min_weight: 5,
+            min_points: 5,
             max_validators: 10,
             epoch_reward: coin(100, "eth"),
             scaling: None,
@@ -80,7 +80,7 @@ fn validators_query_pagination() {
         .with_operators(&members)
         .with_epoch_reward(coin(100, "eth"))
         .with_max_validators(10)
-        .with_min_weight(2)
+        .with_min_points(2)
         .with_epoch_length(3600)
         .build();
 
@@ -127,7 +127,7 @@ fn simulate_validators() {
         .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
         .with_operators(&members)
         .with_max_validators(2)
-        .with_min_weight(5)
+        .with_min_points(5)
         .build();
 
     assert_active_validators(
@@ -195,7 +195,7 @@ fn list_validators() {
     let suite = SuiteBuilder::new()
         .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
         .with_operators(&members)
-        .with_min_weight(5)
+        .with_min_points(5)
         .build();
 
     assert_operators(
@@ -216,7 +216,7 @@ fn list_validators_paginated() {
     let suite = SuiteBuilder::new()
         .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
         .with_operators(&members)
-        .with_min_weight(5)
+        .with_min_points(5)
         .build();
 
     let page1 = suite.list_validators(None, 2).unwrap();

--- a/contracts/tgrade-valset/src/multitest/migration.rs
+++ b/contracts/tgrade-valset/src/multitest/migration.rs
@@ -5,19 +5,19 @@ use crate::msg::MigrateMsg;
 fn migration_can_alter_cfg() {
     let mut suite = SuiteBuilder::new()
         .with_max_validators(6)
-        .with_min_weight(3)
+        .with_min_points(3)
         .build();
     let admin = suite.admin().to_string();
 
     let cfg = suite.config().unwrap();
     assert_eq!(cfg.max_validators, 6);
-    assert_eq!(cfg.min_weight, 3);
+    assert_eq!(cfg.min_points, 3);
 
     suite
         .migrate(
             &admin,
             &MigrateMsg {
-                min_weight: Some(5),
+                min_points: Some(5),
                 max_validators: Some(10),
             },
         )
@@ -25,5 +25,5 @@ fn migration_can_alter_cfg() {
 
     let cfg = suite.config().unwrap();
     assert_eq!(cfg.max_validators, 10);
-    assert_eq!(cfg.min_weight, 5);
+    assert_eq!(cfg.min_points, 5);
 }

--- a/contracts/tgrade-valset/src/multitest/stake.rs
+++ b/contracts/tgrade-valset/src/multitest/stake.rs
@@ -15,7 +15,7 @@ fn init_and_query_state() {
     let suite = SuiteBuilder::new()
         .with_stake("usdc", 100u128)
         .with_operators(&ops)
-        .with_min_weight(5)
+        .with_min_points(5)
         .with_max_validators(10)
         .with_epoch_reward(epoch_reward.clone())
         .build();
@@ -26,7 +26,7 @@ fn init_and_query_state() {
         cfg,
         Config {
             membership: cfg.membership.clone(),
-            min_weight: 5,
+            min_points: 5,
             max_validators: 10,
             scaling: None,
             epoch_reward,
@@ -59,7 +59,7 @@ fn init_and_query_state() {
 fn simulate_validators() {
     let bond_denom = "tgrade";
     let tokens_per_weight = 100u128;
-    let min_weight = 2;
+    let min_points = 2;
 
     let ops_owned = addrs(24);
     let operators: Vec<_> = ops_owned.iter().map(String::as_str).collect();
@@ -75,7 +75,7 @@ fn simulate_validators() {
         .with_stake(bond_denom, tokens_per_weight)
         .with_operators(&operators)
         .with_funds(&operator_balances)
-        .with_min_weight(min_weight)
+        .with_min_points(min_points)
         .with_max_validators(10)
         .with_epoch_reward(coin(50_000, "usdc"))
         .build();
@@ -89,7 +89,7 @@ fn simulate_validators() {
     let op1_addr = Addr::unchecked(operators[0]);
 
     // First, he does not bond enough tokens
-    let stake = cosmwasm_std::coins(tokens_per_weight * min_weight as u128 - 1u128, bond_denom);
+    let stake = cosmwasm_std::coins(tokens_per_weight * min_points as u128 - 1u128, bond_denom);
     suite.bond(&op1_addr, &stake).unwrap();
 
     // what do we expect?
@@ -109,14 +109,14 @@ fn simulate_validators() {
     let expected: Vec<_> = vec![ValidatorInfo {
         operator: op1_addr.clone(),
         validator_pubkey: valid_operator(op1_addr.as_ref()).validator_pubkey,
-        power: min_weight,
+        power: min_points,
     }];
     assert_eq!(expected, active);
 
     // Other member bonds twice the minimum amount
     let op2_addr = Addr::unchecked(operators[1]);
 
-    let stake = cosmwasm_std::coins(tokens_per_weight * min_weight as u128 * 2u128, bond_denom);
+    let stake = cosmwasm_std::coins(tokens_per_weight * min_points as u128 * 2u128, bond_denom);
     suite.bond(&op2_addr, &stake).unwrap();
 
     // what do we expect?
@@ -129,12 +129,12 @@ fn simulate_validators() {
         ValidatorInfo {
             operator: op2_addr.clone(),
             validator_pubkey: valid_operator(op2_addr.as_ref()).validator_pubkey,
-            power: min_weight * 2,
+            power: min_points * 2,
         },
         ValidatorInfo {
             operator: op1_addr.clone(),
             validator_pubkey: valid_operator(op1_addr.as_ref()).validator_pubkey,
-            power: min_weight,
+            power: min_points,
         },
     ];
     assert_eq!(expected, active);
@@ -143,7 +143,7 @@ fn simulate_validators() {
     let op3_addr = Addr::unchecked(operators[2]);
 
     let stake = cosmwasm_std::coins(
-        tokens_per_weight * min_weight as u128 * 3u128 - 1u128,
+        tokens_per_weight * min_points as u128 * 3u128 - 1u128,
         bond_denom,
     );
     suite.bond(&op3_addr, &stake).unwrap();
@@ -158,17 +158,17 @@ fn simulate_validators() {
         ValidatorInfo {
             operator: op3_addr.clone(),
             validator_pubkey: valid_operator(op3_addr.as_ref()).validator_pubkey,
-            power: min_weight * 3 - 1,
+            power: min_points * 3 - 1,
         },
         ValidatorInfo {
             operator: op2_addr.clone(),
             validator_pubkey: valid_operator(op2_addr.as_ref()).validator_pubkey,
-            power: min_weight * 2,
+            power: min_points * 2,
         },
         ValidatorInfo {
             operator: op1_addr.clone(),
             validator_pubkey: valid_operator(op1_addr.as_ref()).validator_pubkey,
-            power: min_weight,
+            power: min_points,
         },
     ];
     assert_eq!(expected, active);
@@ -187,12 +187,12 @@ fn simulate_validators() {
         ValidatorInfo {
             operator: op3_addr.clone(),
             validator_pubkey: valid_operator(op3_addr.as_ref()).validator_pubkey,
-            power: min_weight * 3 - 1,
+            power: min_points * 3 - 1,
         },
         ValidatorInfo {
             operator: op2_addr.clone(),
             validator_pubkey: valid_operator(op2_addr.as_ref()).validator_pubkey,
-            power: min_weight * 2,
+            power: min_points * 2,
         },
     ];
     assert_eq!(expected, active);

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -259,7 +259,7 @@ impl SuiteBuilder {
                     admin.clone(),
                     &tg4_stake::msg::InstantiateMsg {
                         denom,
-                        tokens_per_weight,
+                        tokens_per_point: tokens_per_weight,
                         min_bond: Uint128::zero(),
                         unbonding_period: 0,
                         admin: Some(admin.to_string()),

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -77,7 +77,7 @@ pub struct SuiteBuilder {
     /// Valset operators, with optionally provided pubkeys
     operators: Vec<(String, Option<Pubkey>)>,
     #[derivative(Default(value = "1"))]
-    min_weight: u64,
+    min_points: u64,
     /// Maximum number of validators for single epoch
     #[derivative(Default(value = "u32::MAX"))]
     max_validators: u32,
@@ -199,8 +199,8 @@ impl SuiteBuilder {
         self
     }
 
-    pub fn with_min_weight(mut self, min_weight: u64) -> Self {
-        self.min_weight = min_weight;
+    pub fn with_min_points(mut self, min_points: u64) -> Self {
+        self.min_points = min_points;
         self
     }
 
@@ -336,7 +336,7 @@ impl SuiteBuilder {
                 &InstantiateMsg {
                     admin: Some(admin.to_string()),
                     membership: membership.to_string(),
-                    min_weight: self.min_weight,
+                    min_points: self.min_points,
                     max_validators: self.max_validators,
                     epoch_length: self.epoch_length,
                     epoch_reward: self.epoch_reward,
@@ -562,14 +562,14 @@ impl Suite {
     pub fn update_config(
         &mut self,
         executor: &str,
-        min_weight: impl Into<Option<u64>>,
+        min_points: impl Into<Option<u64>>,
         max_validators: impl Into<Option<u32>>,
     ) -> AnyResult<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(executor),
             self.valset.clone(),
             &ExecuteMsg::UpdateConfig {
-                min_weight: min_weight.into(),
+                min_points: min_points.into(),
                 max_validators: max_validators.into(),
             },
             &[],

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -179,7 +179,7 @@ impl SuiteBuilder {
                 .iter()
                 .map(|(addr, weight)| Member {
                     addr: (*addr).to_owned(),
-                    weight: *weight,
+                    points: *weight,
                 })
                 .collect(),
             halflife: halflife.into(),
@@ -226,7 +226,10 @@ impl SuiteBuilder {
 
                 let members = members
                     .into_iter()
-                    .map(|(addr, weight)| Member { addr, weight })
+                    .map(|(addr, weight)| Member {
+                        addr,
+                        points: weight,
+                    })
                     .collect();
 
                 app.instantiate_contract(

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -602,7 +602,7 @@ impl Suite {
             self.app.execute_contract(
                 Addr::unchecked(executor),
                 contract.clone(),
-                &tg4_engagement::msg::ExecuteMsg::WithdrawFunds {
+                &tg4_engagement::msg::ExecuteMsg::WithdrawRewards {
                     owner: None,
                     receiver: None,
                 },
@@ -620,7 +620,7 @@ impl Suite {
         self.app.execute_contract(
             Addr::unchecked(executor),
             self.rewards_contract.clone(),
-            &tg4_engagement::msg::ExecuteMsg::WithdrawFunds {
+            &tg4_engagement::msg::ExecuteMsg::WithdrawRewards {
                 owner: None,
                 receiver: None,
             },

--- a/contracts/tgrade-valset/src/multitest/update_config.rs
+++ b/contracts/tgrade-valset/src/multitest/update_config.rs
@@ -8,39 +8,39 @@ use super::suite::SuiteBuilder;
 fn update_cfg() {
     let mut suite = SuiteBuilder::new()
         .with_max_validators(6)
-        .with_min_weight(3)
+        .with_min_points(3)
         .build();
     let admin = suite.admin().to_string();
 
     let cfg = suite.config().unwrap();
     assert_eq!(cfg.max_validators, 6);
-    assert_eq!(cfg.min_weight, 3);
+    assert_eq!(cfg.min_points, 3);
 
     suite.update_config(&admin, Some(5), Some(10)).unwrap();
 
     let cfg = suite.config().unwrap();
     assert_eq!(cfg.max_validators, 10);
-    assert_eq!(cfg.min_weight, 5);
+    assert_eq!(cfg.min_points, 5);
 }
 
 #[test]
 fn none_values_do_not_alter_cfg() {
     let mut suite = SuiteBuilder::new()
         .with_max_validators(6)
-        .with_min_weight(3)
+        .with_min_points(3)
         .build();
     let admin = suite.admin().to_string();
 
     let cfg = suite.config().unwrap();
     assert_eq!(cfg.max_validators, 6);
-    assert_eq!(cfg.min_weight, 3);
+    assert_eq!(cfg.min_points, 3);
 
     suite.update_config(&admin, None, None).unwrap();
 
     // Make sure the values haven't changed.
     let cfg = suite.config().unwrap();
     assert_eq!(cfg.max_validators, 6);
-    assert_eq!(cfg.min_weight, 3);
+    assert_eq!(cfg.min_points, 3);
 }
 
 #[test]

--- a/contracts/tgrade-valset/src/rewards.rs
+++ b/contracts/tgrade-valset/src/rewards.rs
@@ -54,7 +54,7 @@ pub fn pay_block_rewards(
             reward_pool -= reward;
             messages.push(SubMsg::new(WasmMsg::Execute {
                 contract_addr: contract.contract.to_string(),
-                msg: to_binary(&DistributionMsg::DistributeFunds {})?,
+                msg: to_binary(&DistributionMsg::DistributeRewards {})?,
                 funds: coins(reward.into(), &block_reward.denom),
             }));
         }
@@ -64,7 +64,7 @@ pub fn pay_block_rewards(
     if reward_pool > Uint128::zero() {
         messages.push(SubMsg::new(WasmMsg::Execute {
             contract_addr: config.rewards_contract.to_string(),
-            msg: to_binary(&RewardsDistribution::DistributeFunds {})?,
+            msg: to_binary(&RewardsDistribution::DistributeRewards {})?,
             funds: coins(reward_pool.into(), &block_reward.denom),
         }));
     }

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -12,17 +12,17 @@ use tg_bindings::{Ed25519Pubkey, Pubkey};
 pub struct Config {
     /// address of a tg4 contract with the raw membership used to feed the validator set
     pub membership: Tg4Contract,
-    /// minimum weight needed by an address in `membership` to be considered for the validator set.
-    /// 0-weight members are always filtered out.
+    /// minimum points needed by an address in `membership` to be considered for the validator set.
+    /// 0-point members are always filtered out.
     /// TODO: if we allow sub-1 scaling factors, determine if this is pre-/post- scaling
-    /// (use weight for tg4, power for tendermint)
-    pub min_weight: u64,
+    /// (use points for tg4, power for tendermint)
+    pub min_points: u64,
     /// The maximum number of validators that can be included in the Tendermint validator set.
     /// If there are more validators than slots, we select the top N by membership weight
     /// descending. (In case of ties at the last slot, select by "first" tendermint pubkey
     /// lexicographically sorted).
     pub max_validators: u32,
-    /// A scaling factor to multiply tg4-engagement weights to produce the tendermint validator power
+    /// A scaling factor to multiply tg4-engagement points to produce the tendermint validator power
     /// (TODO: should we allow this to reduce weight? Like 1/1000?)
     pub scaling: Option<u32>,
     /// Total reward paid out each epoch. This will be split among all validators during the last

--- a/packages/tg4/examples/schema.rs
+++ b/packages/tg4/examples/schema.rs
@@ -5,7 +5,7 @@ use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 pub use tg4::{
     AdminResponse, Member, MemberChangedHookMsg, MemberListResponse, MemberResponse, Tg4ExecuteMsg,
-    Tg4QueryMsg, TotalWeightResponse,
+    Tg4QueryMsg, TotalPointsResponse,
 };
 
 fn main() {
@@ -19,6 +19,6 @@ fn main() {
     export_schema(&schema_for!(AdminResponse), &out_dir);
     export_schema(&schema_for!(MemberListResponse), &out_dir);
     export_schema(&schema_for!(MemberResponse), &out_dir);
-    export_schema(&schema_for!(TotalWeightResponse), &out_dir);
+    export_schema(&schema_for!(TotalPointsResponse), &out_dir);
     export_schema(&schema_for!(MemberChangedHookMsg), &out_dir);
 }

--- a/packages/tg4/src/helpers.rs
+++ b/packages/tg4/src/helpers.rs
@@ -173,7 +173,7 @@ impl Tg4Contract {
             at_height: Some(height),
         })?;
         let res: MemberResponse = querier.query(&query)?;
-        Ok(res.weight)
+        Ok(res.points)
     }
 
     pub fn list_members(
@@ -194,7 +194,7 @@ impl Tg4Contract {
         limit: Option<u32>,
     ) -> StdResult<Vec<Member>> {
         let query =
-            self.encode_smart_query(Tg4QueryMsg::ListMembersByWeight { start_after, limit })?;
+            self.encode_smart_query(Tg4QueryMsg::ListMembersByPoints { start_after, limit })?;
         let res: MemberListResponse = querier.query(&query)?;
         Ok(res.members)
     }

--- a/packages/tg4/src/helpers.rs
+++ b/packages/tg4/src/helpers.rs
@@ -187,7 +187,7 @@ impl Tg4Contract {
         Ok(res.members)
     }
 
-    pub fn list_members_by_weight(
+    pub fn list_members_by_points(
         &self,
         querier: &QuerierWrapper,
         start_after: Option<Member>,

--- a/packages/tg4/src/lib.rs
+++ b/packages/tg4/src/lib.rs
@@ -8,6 +8,6 @@ pub use crate::hook::{MemberChangedHookMsg, MemberDiff};
 pub use crate::msg::Tg4ExecuteMsg;
 pub use crate::query::{
     member_key, AdminResponse, HooksResponse, Member, MemberListResponse, MemberResponse,
-    Tg4QueryMsg, TotalWeightResponse, MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS, MEMBERS_KEY,
+    Tg4QueryMsg, TotalPointsResponse, MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS, MEMBERS_KEY,
     TOTAL_KEY,
 };

--- a/packages/tg4/src/query.rs
+++ b/packages/tg4/src/query.rs
@@ -6,16 +6,16 @@ use serde::{Deserialize, Serialize};
 pub enum Tg4QueryMsg {
     /// Return AdminResponse
     Admin {},
-    /// Return TotalWeightResponse
-    TotalWeight {},
+    /// Return TotalPointsResponse
+    TotalPoints {},
     /// Returns MemberListResponse.
     /// The result is sorted by address ascending
     ListMembers {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    /// Returns MemberListResponse, sorted by weight descending
-    ListMembersByWeight {
+    /// Returns MemberListResponse, sorted by points descending
+    ListMembersByPoints {
         start_after: Option<Member>,
         limit: Option<u32>,
     },
@@ -33,13 +33,13 @@ pub struct AdminResponse {
     pub admin: Option<String>,
 }
 
-/// A group member has a weight associated with them.
+/// A group member has some points associated with them.
 /// This may all be equal, or may have meaning in the app that
 /// makes use of the group (eg. voting power)
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Member {
     pub addr: String,
-    pub weight: u64,
+    pub points: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -49,12 +49,12 @@ pub struct MemberListResponse {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct MemberResponse {
-    pub weight: Option<u64>,
+    pub points: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct TotalWeightResponse {
-    pub weight: u64,
+pub struct TotalPointsResponse {
+    pub points: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/utils/src/member_indexes.rs
+++ b/packages/utils/src/member_indexes.rs
@@ -13,12 +13,12 @@ pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
 
 pub struct MemberIndexes<'a> {
     // Weights (multi-)index (deserializing the (hidden) pk to Addr)
-    pub weight: MultiIndex<'a, u64, u64, Addr>,
+    pub points: MultiIndex<'a, u64, u64, Addr>,
 }
 
 impl<'a> IndexList<u64> for MemberIndexes<'a> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
-        let v: Vec<&dyn Index<u64>> = vec![&self.weight];
+        let v: Vec<&dyn Index<u64>> = vec![&self.points];
         Box::new(v.into_iter())
     }
 }
@@ -29,7 +29,7 @@ impl<'a> IndexList<u64> for MemberIndexes<'a> {
 /// The weight index is not snapshotted; only the current weights are indexed at any given time.
 pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, u64, MemberIndexes<'a>> {
     let indexes = MemberIndexes {
-        weight: MultiIndex::new(|&w| w, tg4::MEMBERS_KEY, "members__weight"),
+        points: MultiIndex::new(|&w| w, tg4::MEMBERS_KEY, "members__points"),
     };
     IndexedSnapshotMap::new(
         tg4::MEMBERS_KEY,

--- a/packages/voting-contract/src/lib.rs
+++ b/packages/voting-contract/src/lib.rs
@@ -430,7 +430,7 @@ pub fn list_voters(
         .into_iter()
         .map(|member| VoterDetail {
             addr: member.addr,
-            weight: member.weight,
+            weight: member.points,
         })
         .collect();
     Ok(VoterListResponse { voters })

--- a/packages/voting-contract/src/multitest/suite.rs
+++ b/packages/voting-contract/src/multitest/suite.rs
@@ -41,7 +41,7 @@ impl SuiteBuilder {
     pub fn with_member(mut self, addr: &str, weight: u64) -> Self {
         self.members.push(Member {
             addr: addr.to_owned(),
-            weight,
+            points: weight,
         });
         self
     }
@@ -125,7 +125,7 @@ impl Suite {
             .iter()
             .map(|(addr, weight)| Member {
                 addr: (*addr).to_owned(),
-                weight: *weight,
+                points: *weight,
             })
             .collect();
 


### PR DESCRIPTION
Part 1 of https://github.com/confio/tgrade-contracts/issues/272 
(the rest must be done in tgrade-contracts after merging this, tagging and updating deps).

Become more consistent in naming.

**points** are used for non-transferable items like voting power

**rewards** are used for funds being paid out

I believe I made all needed adjustments in `msg.rs` and `state.rs` files, aka the public interfaces. Some docstrings need to be updated, but more importantly, a whole lot of local variables.

I just made the first pass to clarify which names are desired where. After 0.5.5 is tagged, someone can please take this branch over (make a new PR if you want) 

TODO:
- [ ] Check over local variable and function names
- [ ] Replace weight -> points in usages of tg3::Vote/VoteInfo (all voting contracts) - do not change in cw-plus, but rather use a custom version of those (tg3?) in our packages with consistent naming
- [x] Add a MIGRATION.md that has a brief overview of breaking changes in public API (to help Go and JS clients update quickly)