### PR TITLE
Validator set query pagination

### DIFF
--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -281,8 +281,10 @@ pub enum QueryMsg {
     },
 
     /// List the current validator set, sorted by power descending
-    /// (no pagination - reasonable limit from max_validators)
-    ListActiveValidators {},
+    ListActiveValidators {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
 
     /// This will calculate who the new validators would be if
     /// we recalculated end block right now.

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -72,6 +72,52 @@ fn initialization() {
 }
 
 #[test]
+fn validators_query_pagination() {
+    let members = vec!["member1", "member2", "member3", "member4", "member5"];
+
+    let suite = SuiteBuilder::new()
+        .with_engagement(&members_init(&members, &[2, 3, 5, 8, 4]))
+        .with_operators(&members)
+        .with_epoch_reward(coin(100, "eth"))
+        .with_max_validators(10)
+        .with_min_weight(2)
+        .with_epoch_length(3600)
+        .build();
+
+    // Query without pagination
+    assert_active_validators(
+        &suite.list_active_validators(None, None).unwrap(),
+        &[
+            (members[0], 2),
+            (members[1], 3),
+            (members[2], 5),
+            (members[3], 8),
+            (members[4], 4),
+        ],
+    );
+
+    // List only first 3
+    let page = suite.list_active_validators(None, 3).unwrap();
+    assert_active_validators(&page, &[(members[2], 5), (members[3], 8), (members[4], 4)]);
+
+    // List 2 entries after 2rd validator
+    assert_active_validators(
+        &suite
+            .list_active_validators(page.last().unwrap().operator.to_string(), 2)
+            .unwrap(),
+        &[(members[0], 2), (members[1], 3)],
+    );
+
+    // Starting at unknown validator will return empty query result
+    assert_active_validators(
+        &suite
+            .list_active_validators("unknown_member".to_owned(), None)
+            .unwrap(),
+        &[],
+    );
+}
+
+#[test]
 fn simulate_validators() {
     let members = vec![
         "member1", "member2", "member3", "member4", "member5", "member6",

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -59,7 +59,7 @@ fn initialization() {
 
     // Validators should be set on genesis processing block
     assert_active_validators(
-        &suite.list_active_validators().unwrap(),
+        &suite.list_active_validators(None, None).unwrap(),
         &[(members[2], 5), (members[3], 8)],
     );
 
@@ -90,7 +90,7 @@ fn simulate_validators() {
     );
 
     assert_active_validators(
-        &suite.list_active_validators().unwrap(),
+        &suite.list_active_validators(None, None).unwrap(),
         &[(members[4], 13), (members[5], 21)],
     );
 }

--- a/contracts/tgrade-valset/src/multitest/jailing.rs
+++ b/contracts/tgrade-valset/src/multitest/jailing.rs
@@ -308,7 +308,7 @@ fn enb_block_ignores_jailed_validators() {
     suite.advance_epoch().unwrap();
 
     assert_active_validators(
-        &suite.list_active_validators().unwrap(),
+        &suite.list_active_validators(None, None).unwrap(),
         &[(members[2], 5), (members[3], 8)],
     );
 }

--- a/contracts/tgrade-valset/src/multitest/stake.rs
+++ b/contracts/tgrade-valset/src/multitest/stake.rs
@@ -39,7 +39,7 @@ fn init_and_query_state() {
     );
 
     // no initial active set
-    let active = suite.list_active_validators().unwrap();
+    let active = suite.list_active_validators(None, None).unwrap();
     assert_eq!(active, vec![]);
 
     // check a validator is set
@@ -82,7 +82,7 @@ fn simulate_validators() {
 
     // what do we expect?
     // 1..24 have pubkeys registered, we take the top 10, but none have stake yet, so zero
-    let active = suite.list_active_validators().unwrap();
+    let active = suite.list_active_validators(None, None).unwrap();
     assert_eq!(0, active.len());
 
     // One member bonds needed tokens to have enough weight

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -671,11 +671,18 @@ impl Suite {
         Ok(resp.validators)
     }
 
-    pub fn list_active_validators(&self) -> StdResult<Vec<ValidatorInfo>> {
-        let resp: ListActiveValidatorsResponse = self
-            .app
-            .wrap()
-            .query_wasm_smart(self.valset.clone(), &QueryMsg::ListActiveValidators {})?;
+    pub fn list_active_validators(
+        &self,
+        start_after: impl Into<Option<String>>,
+        limit: impl Into<Option<u32>>,
+    ) -> StdResult<Vec<ValidatorInfo>> {
+        let resp: ListActiveValidatorsResponse = self.app.wrap().query_wasm_smart(
+            self.valset.clone(),
+            &QueryMsg::ListActiveValidators {
+                start_after: start_after.into(),
+                limit: limit.into(),
+            },
+        )?;
 
         Ok(resp.validators)
     }


### PR DESCRIPTION
Closes #33. Quick and dirty solution (linear search over the validator set, to simulate `start_after`).