### PR TITLE
Release v0.6.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,65 @@
 # Changelog
 
-
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.5.4...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-alpha1...HEAD)
+
+**Breaking changes:**
+
+- `valset`: Optimize VALIDATORS storage [\#42](https://github.com/confio/poe-contracts/issues/42)
+- Optimize validators storage [\#61](https://github.com/confio/poe-contracts/pull/61) ([maurolacy](https://github.com/maurolacy))
+
+**Closed issues:**
+
+- Voting's helper `update_status()` should save changed status [\#62](https://github.com/confio/poe-contracts/issues/62)
+- \[voting-contract\] More status issues [\#55](https://github.com/confio/poe-contracts/issues/55)
+
+**Merged pull requests:**
+
+- Voting Contract: vote and close uses current status [\#60](https://github.com/confio/poe-contracts/pull/60) ([ueco-jb](https://github.com/ueco-jb))
+
+## [v0.6.0-alpha1](https://github.com/confio/poe-contracts/tree/v0.6.0-alpha1) (2022-01-31)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.5.5...v0.6.0-alpha1)
+
+**Breaking changes:**
+
+- \[voting-contract\] Record proposal creator [\#31](https://github.com/confio/poe-contracts/issues/31)
+
+**Closed issues:**
+
+- Validator Voting: check `migrate_msg` content to be \>0 [\#46](https://github.com/confio/poe-contracts/issues/46)
+- Add Open Text Proposals [\#15](https://github.com/confio/poe-contracts/issues/15)
+
+**Merged pull requests:**
+
+- Update rust toolchain to v1.58.1 [\#58](https://github.com/confio/poe-contracts/pull/58) ([uint](https://github.com/uint))
+- 0.6.0-alpha1 release [\#56](https://github.com/confio/poe-contracts/pull/56) ([uint](https://github.com/uint))
+- Voting contract: save info about creator of proposal [\#54](https://github.com/confio/poe-contracts/pull/54) ([ueco-jb](https://github.com/ueco-jb))
+- Fix `remove_hook` helper [\#53](https://github.com/confio/poe-contracts/pull/53) ([maurolacy](https://github.com/maurolacy))
+- Validator set query pagination [\#51](https://github.com/confio/poe-contracts/pull/51) ([maurolacy](https://github.com/maurolacy))
+- ValidatorVoting - make sure proposal migrate msg is not empty [\#48](https://github.com/confio/poe-contracts/pull/48) ([ueco-jb](https://github.com/ueco-jb))
+- Fix tg4-engagement docs / comments [\#47](https://github.com/confio/poe-contracts/pull/47) ([maurolacy](https://github.com/maurolacy))
+- valset: Add a feature to update `min_weight` and `max_validators` [\#45](https://github.com/confio/poe-contracts/pull/45) ([uint](https://github.com/uint))
+- Update rust to v1.54.0 in CI [\#43](https://github.com/confio/poe-contracts/pull/43) ([maurolacy](https://github.com/maurolacy))
+- Valset: Fix JailMsg inconsistencies [\#39](https://github.com/confio/poe-contracts/pull/39) ([ueco-jb](https://github.com/ueco-jb))
+- Valset: better unjail error message when jail lock didn't expire [\#38](https://github.com/confio/poe-contracts/pull/38) ([ueco-jb](https://github.com/ueco-jb))
+- Store information about operators' validator status [\#37](https://github.com/confio/poe-contracts/pull/37) ([uint](https://github.com/uint))
+- Fix tag consolidation for matching CHANGELOG entries [\#32](https://github.com/confio/poe-contracts/pull/32) ([maurolacy](https://github.com/maurolacy))
+- Open Text Proposals [\#27](https://github.com/confio/poe-contracts/pull/27) ([uint](https://github.com/uint))
+
+## [v0.5.5](https://github.com/confio/poe-contracts/tree/v0.5.5) (2022-01-27)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.5.4...v0.5.5)
+
+**Closed issues:**
+
+- Fix wasm-build [\#41](https://github.com/confio/poe-contracts/issues/41)
+- valset: better error message when jail lock not expired [\#34](https://github.com/confio/poe-contracts/issues/34)
+- valset: limit active\_valset query and add pagination [\#33](https://github.com/confio/poe-contracts/issues/33)
+- valset: update max\_validators [\#28](https://github.com/confio/poe-contracts/issues/28)
+- valset: mark "active" validators in ValidatorInfo [\#23](https://github.com/confio/poe-contracts/issues/23)
+- Fix JailMsg inconsistencies [\#20](https://github.com/confio/poe-contracts/issues/20)
 
 ## [v0.5.4](https://github.com/confio/poe-contracts/tree/v0.5.4) (2022-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-alpha1...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-beta1...HEAD)
+
+## [v0.6.0-alpha1](https://github.com/confio/poe-contracts/tree/v0.6.0-beta1) (2022-02-03)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-alpha1...v0.6.0-beta1)
 
 **Breaking changes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-beta1...HEAD)
 
-## [v0.6.0-alpha1](https://github.com/confio/poe-contracts/tree/v0.6.0-beta1) (2022-02-03)
+## [v0.6.0-beta1](https://github.com/confio/poe-contracts/tree/v0.6.0-beta1) (2022-02-03)
 
 [Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-alpha1...v0.6.0-beta1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 **Breaking changes:**
 
 - \[voting-contract\] Record proposal creator [\#31](https://github.com/confio/poe-contracts/issues/31)
+- Validator set query pagination [\#51](https://github.com/confio/poe-contracts/pull/51) ([maurolacy](https://github.com/maurolacy))
+- valset: Add a feature to update `min_weight` and `max_validators` [\#45](https://github.com/confio/poe-contracts/pull/45) ([uint](https://github.com/uint))
+- Store information about operators' validator status [\#37](https://github.com/confio/poe-contracts/pull/37) ([uint](https://github.com/uint))
 
 **Closed issues:**
 
@@ -41,14 +44,11 @@
 - 0.6.0-alpha1 release [\#56](https://github.com/confio/poe-contracts/pull/56) ([uint](https://github.com/uint))
 - Voting contract: save info about creator of proposal [\#54](https://github.com/confio/poe-contracts/pull/54) ([ueco-jb](https://github.com/ueco-jb))
 - Fix `remove_hook` helper [\#53](https://github.com/confio/poe-contracts/pull/53) ([maurolacy](https://github.com/maurolacy))
-- Validator set query pagination [\#51](https://github.com/confio/poe-contracts/pull/51) ([maurolacy](https://github.com/maurolacy))
 - ValidatorVoting - make sure proposal migrate msg is not empty [\#48](https://github.com/confio/poe-contracts/pull/48) ([ueco-jb](https://github.com/ueco-jb))
 - Fix tg4-engagement docs / comments [\#47](https://github.com/confio/poe-contracts/pull/47) ([maurolacy](https://github.com/maurolacy))
-- valset: Add a feature to update `min_weight` and `max_validators` [\#45](https://github.com/confio/poe-contracts/pull/45) ([uint](https://github.com/uint))
 - Update rust to v1.54.0 in CI [\#43](https://github.com/confio/poe-contracts/pull/43) ([maurolacy](https://github.com/maurolacy))
 - Valset: Fix JailMsg inconsistencies [\#39](https://github.com/confio/poe-contracts/pull/39) ([ueco-jb](https://github.com/ueco-jb))
 - Valset: better unjail error message when jail lock didn't expire [\#38](https://github.com/confio/poe-contracts/pull/38) ([ueco-jb](https://github.com/ueco-jb))
-- Store information about operators' validator status [\#37](https://github.com/confio/poe-contracts/pull/37) ([uint](https://github.com/uint))
 - Fix tag consolidation for matching CHANGELOG entries [\#32](https://github.com/confio/poe-contracts/pull/32) ([maurolacy](https://github.com/maurolacy))
 - Open Text Proposals [\#27](https://github.com/confio/poe-contracts/pull/27) ([uint](https://github.com/uint))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.6.0-alpha1" }
-tg-utils = { version = "0.6.0-alpha1", path = "../../packages/utils" }
-tg-bindings = { version = "0.6.0-alpha1", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-beta1" }
+tg-utils = { version = "0.6.0-beta1", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.0-beta1", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
 cw-multi-test = { version = "0.11.0" }
-tg-bindings-test = { version = "0.6.0-alpha1", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.6.0-beta1", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw20 = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.6.0-alpha1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-alpha1" }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-alpha1" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-beta1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-beta1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-beta1" }
 cosmwasm-std = "1.0.0-beta"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -47,7 +47,7 @@ cosmwasm-schema = { version = "1.0.0-beta" }
 # version's workaround for issue with cyclic dependencies during cargo publish
 # https://github.com/rust-lang/cargo/issues/4242
 tg4-engagement = { path = "../tg4-engagement", version = ">= 0.5.5, <= 0.6.0-alpha1", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.6.0-alpha1", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.6.0-beta1", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -46,7 +46,7 @@ cw-multi-test = { version = "0.11.0" }
 cosmwasm-schema = { version = "1.0.0-beta" }
 # version's workaround for issue with cyclic dependencies during cargo publish
 # https://github.com/rust-lang/cargo/issues/4242
-tg4-engagement = { path = "../tg4-engagement", version = ">= 0.5.5, <= 0.6.0-alpha1", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-beta1", features = ["library"] }
 tg4-stake = { path = "../tg4-stake", version = "0.6.0-beta1", features = ["library"] }
 
 [[bench]]

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.6.0-alpha1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-alpha1" }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-alpha1" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-beta1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-beta1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-beta1" }
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -22,15 +22,15 @@ cw3 = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-alpha1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-alpha1" }
-tg-voting-contract = { version = "0.6.0-alpha1", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-alpha1", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-beta1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-beta1" }
+tg-voting-contract = { version = "0.6.0-beta1", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-beta1", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-alpha1" }
-tg4 = { path = "../../packages/tg4", version = "0.6.0-alpha1" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-beta1" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-beta1" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/confio/poe-contracts"
@@ -25,7 +25,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta"
 cw-storage-plus = "0.11.0"
-tg-bindings = { version = "0.6.0-alpha1", path = "../../packages/bindings" }
+tg-bindings = { version = "0.6.0-beta1", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -22,9 +22,9 @@ cw3 = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-alpha1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-alpha1" }
-tg-voting-contract = { version = "0.6.0-alpha1", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-beta1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-beta1" }
+tg-voting-contract = { version = "0.6.0-beta1", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg-bindings-test = { version = "0.6.0-alpha1", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.6.0-alpha1", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.6.0-alpha1", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.6.0-alpha1" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-alpha1", features = ["library"] }
+tg-bindings-test = { version = "0.6.0-beta1", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.6.0-beta1", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.6.0-beta1", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-beta1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-beta1", features = ["library"] }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -29,9 +29,9 @@ integration = ["bech32", "cosmwasm-vm"]
 [dependencies]
 cw-utils = { version = "0.11.0" }
 cw2 = { version = "0.11.0" }
-tg4 = { path = "../../packages/tg4", version = "0.6.0-alpha1" }
-tg-bindings = { version = "0.6.0-alpha1", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.0-alpha1", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-beta1" }
+tg-bindings = { version = "0.6.0-beta1", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.0-beta1", path = "../../packages/utils" }
 cw-controllers = { version = "0.11.0" }
 cw-storage-plus = { version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta4" }
@@ -46,10 +46,10 @@ cosmwasm-vm = { version = "1.0.0-beta4", optional = true, default-features = fal
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta4" }
 cw-multi-test = "0.11.0"
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-alpha1" }
-tg4-stake = { path = "../tg4-stake", version = "0.6.0-alpha1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-beta1" }
+tg4-stake = { path = "../tg4-stake", version = "0.6.0-beta1" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-alpha1" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-beta1" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.11.0"
 cw-storage-plus = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.6.0-alpha1", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.0-alpha1", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.0-beta1", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.0-beta1", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
-tg-bindings-test = { version = "0.6.0-alpha1", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.6.0-beta1", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.6.0-alpha1", path = "../bindings" }
+tg-bindings = { version = "0.6.0-beta1", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta"
-tg-voting-contract = { path = "../voting-contract", version = "0.6.0-alpha1" }
+tg-voting-contract = { path = "../voting-contract", version = "0.6.0-beta1" }

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.6.0-alpha1" }
+tg-bindings = { path = "../bindings", version = "0.6.0-beta1" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.11.0"
 cw2 = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.6.0-alpha1" }
-tg-bindings = { path = "../bindings", version = "0.6.0-alpha1" }
+tg4 = { path = "../tg4", version = "0.6.0-beta1" }
+tg-bindings = { path = "../bindings", version = "0.6.0-beta1" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.6.0-alpha1"
+version = "0.6.0-beta1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -17,9 +17,9 @@ cw-storage-plus = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.6.0-alpha1" }
-tg-bindings = { path = "../bindings", version = "0.6.0-alpha1" }
-tg-utils = { version = "0.6.0-alpha1", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.6.0-beta1" }
+tg-bindings = { path = "../bindings", version = "0.6.0-beta1" }
+tg-utils = { version = "0.6.0-beta1", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-alpha1" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.0-alpha1", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-beta1" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.0-beta1", features = ["library"] }


### PR DESCRIPTION
Closes #67.

For reference, unified diff of schemas between v0.5.5 and this version:
[schema_diffs-v0.5.5-v0.6.0-beta1.txt](https://github.com/confio/poe-contracts/files/7994478/schema_diffs-v0.5.5-v0.6.0-beta1.txt)
