### PR TITLE
Validator set tie breaking

### DIFF
--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1208,6 +1208,60 @@ mod tests {
                 }
             ]
         );
+
+        // Test pagination / limits work
+        let members = list_members_by_weight(deps.as_ref(), None, Some(1))
+            .unwrap()
+            .members;
+        assert_eq!(members.len(), 1);
+        // Assert the set is proper
+        assert_eq!(
+            members,
+            vec![Member {
+                addr: USER1.into(),
+                weight: 11,
+                start_height: 12345
+            },]
+        );
+
+        // Next page
+        let start_after = Some(members[0].clone());
+        let members = list_members_by_weight(deps.as_ref(), start_after, Some(1))
+            .unwrap()
+            .members;
+        assert_eq!(members.len(), 1);
+        // Assert the set is proper
+        assert_eq!(
+            members,
+            vec![Member {
+                addr: USER3.into(),
+                weight: 6,
+                start_height: 12355
+            },]
+        );
+
+        // Next page
+        let start_after = Some(members[0].clone());
+        let members = list_members_by_weight(deps.as_ref(), start_after, Some(1))
+            .unwrap()
+            .members;
+        assert_eq!(members.len(), 1);
+        // Assert the set is proper
+        assert_eq!(
+            members,
+            vec![Member {
+                addr: USER2.into(),
+                weight: 6,
+                start_height: 12365
+            },]
+        );
+
+        // Assert there's no more
+        let start_after = Some(members[0].clone());
+        let members = list_members_by_weight(deps.as_ref(), start_after, Some(1))
+            .unwrap()
+            .members;
+        assert_eq!(members.len(), 0);
     }
 
     #[test]

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -862,8 +862,9 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after
-        .map(|m| Bound::exclusive((m.weight, m.start_height, m.addr.as_str()).joined_key()));
+    let start = start_after.map(|m| {
+        Bound::exclusive((m.weight, -(m.start_height as i64), m.addr.as_str()).joined_key())
+    });
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -862,8 +862,8 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    // FIXME: Wrong bound now! (use type-safe bounds)
-    let start = start_after.map(|m| Bound::exclusive((m.weight, 0, m.addr.as_str()).joined_key()));
+    let start = start_after
+        .map(|m| Bound::exclusive((m.weight, m.start_height, m.addr.as_str()).joined_key()));
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight

--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -189,11 +189,12 @@ mod tests {
 
     #[test]
     fn deserialize_json_to_sudo_msg() {
-        let message = r#"{"update_member": {"addr": "xxx", "weight": 123}}"#;
+        let message = r#"{"update_member": {"addr": "xxx", "weight": 123, "start_height": 456}}"#;
         assert_eq!(
             SudoMsg::UpdateMember(Member {
                 addr: "xxx".to_string(),
-                weight: 123
+                weight: 123,
+                start_height: 456
             }),
             cosmwasm_std::from_slice::<SudoMsg>(message.as_bytes()).unwrap()
         );

--- a/contracts/tg4-engagement/src/multitest.rs
+++ b/contracts/tg4-engagement/src/multitest.rs
@@ -11,6 +11,7 @@ fn member(addr: &str, weight: u64) -> Member {
     Member {
         addr: addr.to_owned(),
         weight,
+        start_height: 0, // FIXME?
     }
 }
 

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -26,6 +26,7 @@ pub fn expected_members(members: Vec<(&str, u64)>) -> Vec<Member> {
         .map(|(addr, weight)| Member {
             addr: addr.to_owned(),
             weight,
+            start_height: 0, // FIXME?
         })
         .collect()
 }
@@ -46,6 +47,7 @@ impl SuiteBuilder {
         self.members.push(Member {
             addr: addr.to_owned(),
             weight,
+            start_height: 0, // FIXME?
         });
         self
     }
@@ -212,6 +214,7 @@ impl Suite {
             .map(|(addr, weight)| Member {
                 addr: (*addr).to_owned(),
                 weight: *weight,
+                start_height: 0, // FIXME?
             })
             .collect();
 

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -452,8 +452,9 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after
-        .map(|m| Bound::exclusive((m.weight, m.start_height, m.addr.as_str()).joined_key()));
+    let start = start_after.map(|m| {
+        Bound::exclusive((m.weight, -(m.start_height as i64), m.addr.as_str()).joined_key())
+    });
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -452,8 +452,8 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    // FIXME: Wrong bound now! (use type-safe bounds)
-    let start = start_after.map(|m| Bound::exclusive((m.weight, 0, m.addr).joined_key()));
+    let start = start_after
+        .map(|m| Bound::exclusive((m.weight, m.start_height, m.addr.as_str()).joined_key()));
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -111,7 +111,7 @@ fn initialize_members(
             if let Some(right) = other {
                 let weight = poe_function.rewards(member.weight, right)?;
                 total += weight;
-                members().save(deps.storage, &addr, &weight, height)?;
+                members().save(deps.storage, &addr, &(weight, height), height)?;
             }
         }
         // and get the next page
@@ -208,13 +208,18 @@ pub fn update_members(
 
         // update the total with changes.
         // to calculate this, we need to load the old weight before saving the new weight
-        let prev_weight = mems.may_load(deps.storage, &member_addr)?;
+        let (prev_weight, start_height) = match mems.may_load(deps.storage, &member_addr)? {
+            Some((weight, start_height)) => (Some(weight), start_height),
+            None => (None, height),
+        };
         total -= prev_weight.unwrap_or_default();
         total += new_weight.unwrap_or_default();
 
         // store the new value
         match new_weight {
-            Some(weight) => mems.save(deps.storage, &member_addr, &weight, height)?,
+            Some(weight) => {
+                mems.save(deps.storage, &member_addr, &(weight, start_height), height)?
+            }
             None => mems.remove(deps.storage, &member_addr, height)?,
         };
 
@@ -400,7 +405,8 @@ fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<Memb
     let weight = match height {
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
-    }?;
+    }?
+    .map(|(weight, _start_height)| weight);
     Ok(MemberResponse { weight })
 }
 
@@ -421,7 +427,7 @@ fn list_members(
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (addr, weight) = item?;
+            let (addr, (weight, _start_height)) = item?;
             Ok(Member {
                 addr: addr.into(),
                 weight,
@@ -438,14 +444,15 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|m| Bound::exclusive((m.weight, m.addr).joined_key()));
+    // FIXME: Wrong bound now! (use type-safe bounds)
+    let start = start_after.map(|m| Bound::exclusive((m.weight, 0, m.addr).joined_key()));
     let members: StdResult<Vec<_>> = members()
         .idx
         .weight
         .range(deps.storage, None, start, Order::Descending)
         .take(limit)
         .map(|item| {
-            let (addr, weight) = item?;
+            let (addr, (weight, _start_height)) = item?;
             Ok(Member {
                 addr: addr.into(),
                 weight,

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -561,8 +561,9 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after
-        .map(|m| Bound::exclusive((m.weight, m.start_height, m.addr.as_str()).joined_key()));
+    let start = start_after.map(|m| {
+        Bound::exclusive((m.weight, -(m.start_height as i64), m.addr.as_str()).joined_key())
+    });
 
     let members: StdResult<Vec<_>> = members()
         .idx

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -320,24 +320,28 @@ fn update_membership(
     // update their membership weight
     let new = calc_weight(new_stake, cfg);
     let old = members().may_load(storage, &sender)?;
+    let (old_weight, start_height) = match old {
+        Some((w, h)) => (Some(w), h),
+        None => (None, height),
+    };
 
     // short-circuit if no change
-    if new == old {
+    if new == old_weight {
         return Ok(vec![]);
     }
     // otherwise, record change of weight
     match new.as_ref() {
-        Some(w) => members().save(storage, &sender, w, height),
+        Some(&w) => members().save(storage, &sender, &(w, start_height), height),
         None => members().remove(storage, &sender, height),
     }?;
 
     // update total
     TOTAL.update(storage, |total| -> StdResult<_> {
-        Ok(total + new.unwrap_or_default() - old.unwrap_or_default())
+        Ok(total + new.unwrap_or_default() - old_weight.unwrap_or_default())
     })?;
 
     // alert the hooks
-    let diff = MemberDiff::new(sender, old, new);
+    let diff = MemberDiff::new(sender, old_weight, new);
     HOOKS.prepare_hooks(storage, |h| {
         MemberChangedHookMsg::one(diff.clone())
             .into_cosmos_msg(h)
@@ -510,7 +514,8 @@ fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<Memb
     let weight = match height {
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
-    }?;
+    }?
+    .map(|(weight, _start_height)| weight);
     Ok(MemberResponse { weight })
 }
 
@@ -531,7 +536,7 @@ fn list_members(
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (addr, weight) = item?;
+            let (addr, (weight, _)) = item?;
             Ok(Member {
                 addr: addr.into(),
                 weight,
@@ -548,7 +553,9 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|m| Bound::exclusive((m.weight, m.addr.as_str()).joined_key()));
+    // FIXME: Wrong bound now!
+    // FIXME: Use type-safe bounds (cw-plus v0.12)
+    let start = start_after.map(|m| Bound::exclusive((m.weight, 0, m.addr.as_str()).joined_key()));
 
     let members: StdResult<Vec<_>> = members()
         .idx
@@ -556,7 +563,7 @@ fn list_members_by_weight(
         .range(deps.storage, None, start, Order::Descending)
         .take(limit)
         .map(|item| {
-            let (addr, weight) = item?;
+            let (addr, (weight, _)) = item?;
             Ok(Member {
                 addr: addr.into(),
                 weight,
@@ -983,8 +990,8 @@ mod tests {
 
         // get member votes from raw key
         let member2_raw = deps.storage.get(&member_key(USER2)).unwrap();
-        let member2: u64 = from_slice(&member2_raw).unwrap();
-        assert_eq!(6, member2);
+        let member2: (u64, u64) = from_slice(&member2_raw).unwrap();
+        assert_eq!(6, member2.0);
 
         // and execute misses
         let member3_raw = deps.storage.get(&member_key(USER3));

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -561,9 +561,8 @@ fn list_members_by_weight(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    // FIXME: Wrong bound now!
-    // FIXME: Use type-safe bounds (cw-plus v0.12)
-    let start = start_after.map(|m| Bound::exclusive((m.weight, 0, m.addr.as_str()).joined_key()));
+    let start = start_after
+        .map(|m| Bound::exclusive((m.weight, m.start_height, m.addr.as_str()).joined_key()));
 
     let members: StdResult<Vec<_>> = members()
         .idx

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -53,6 +53,7 @@ impl SuiteBuilder {
         self.group_members.push(Member {
             addr: addr.to_owned(),
             weight,
+            start_height: 0, // FIXME?
         });
         self
     }
@@ -148,6 +149,7 @@ impl SuiteBuilder {
                     add: vec![Member {
                         addr: contract.to_string(),
                         weight: self.contract_weight,
+                        start_height: 0, // FIXME?
                     }],
                 },
                 &[],

--- a/contracts/tgrade-validator-voting/src/multitest/suite.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/suite.rs
@@ -61,6 +61,7 @@ impl SuiteBuilder {
         self.group_members.push(Member {
             addr: addr.to_owned(),
             weight,
+            start_height: 0, // FIXME?
         });
         self
     }

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -786,6 +786,7 @@ fn calculate_diff(
             let member = Member {
                 addr: vi.operator.to_string(),
                 weight: vi.power,
+                start_height: 0, // FIXME?: Currently unused
             };
 
             (update, member)
@@ -1000,6 +1001,7 @@ mod test {
             .map(|(addr, weight)| Member {
                 addr: addr.to_owned(),
                 weight,
+                start_height: 0, // FIXME?
             })
             .collect()
     }

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -180,6 +180,7 @@ impl SuiteBuilder {
                 .map(|(addr, weight)| Member {
                     addr: (*addr).to_owned(),
                     weight: *weight,
+                    start_height: 0, // FIXME?
                 })
                 .collect(),
             halflife: halflife.into(),
@@ -226,7 +227,11 @@ impl SuiteBuilder {
 
                 let members = members
                     .into_iter()
-                    .map(|(addr, weight)| Member { addr, weight })
+                    .map(|(addr, weight)| Member {
+                        addr,
+                        weight,
+                        start_height: 0,
+                    }) // FIXME?
                     .collect();
 
                 app.instantiate_contract(

--- a/packages/tg4/src/helpers.rs
+++ b/packages/tg4/src/helpers.rs
@@ -114,7 +114,7 @@ impl Tg4Contract {
                 if value.is_empty() {
                     Ok(None)
                 } else {
-                    from_slice(&value)
+                    Ok(from_slice::<(u64, u64)>(&value)?.0.into())
                 }
             }
         }

--- a/packages/tg4/src/query.rs
+++ b/packages/tg4/src/query.rs
@@ -40,6 +40,7 @@ pub struct AdminResponse {
 pub struct Member {
     pub addr: String,
     pub weight: u64,
+    pub start_height: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -50,6 +51,7 @@ pub struct MemberListResponse {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct MemberResponse {
     pub weight: Option<u64>,
+    pub start_height: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/utils/src/member_indexes.rs
+++ b/packages/utils/src/member_indexes.rs
@@ -13,23 +13,31 @@ pub const TOTAL: Item<u64> = Item::new(TOTAL_KEY);
 
 pub struct MemberIndexes<'a> {
     // Weights (multi-)index (deserializing the (hidden) pk to Addr)
-    pub weight: MultiIndex<'a, u64, u64, Addr>,
+    pub weight: MultiIndex<'a, (u64, i64), (u64, u64), Addr>,
 }
 
-impl<'a> IndexList<u64> for MemberIndexes<'a> {
-    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
-        let v: Vec<&dyn Index<u64>> = vec![&self.weight];
+impl<'a> IndexList<(u64, u64)> for MemberIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<(u64, u64)>> + '_> {
+        let v: Vec<&dyn Index<(u64, u64)>> = vec![&self.weight];
         Box::new(v.into_iter())
     }
 }
 
 /// Indexed snapshot map for members.
-/// This allows to query the map members, sorted by weight.
-/// The weight index is a `MultiIndex`, as there can be multiple members with the same weight.
+/// The map primary key is `Addr`, and the value is a tuple of `weight`, `start_height` values.
+/// The `(weight, -start_height)` index is a `MultiIndex`, as there can be multiple members with the
+/// same weight, added at the same block height.
+/// The second tuple element of the index is negative, so that lower heights (older members) are sorted first,
+/// as this will be used as a descending index.
+/// This allows to query the map members, sorted by weight, breaking ties by height (and breaking ties by address in turn).
 /// The weight index is not snapshotted; only the current weights are indexed at any given time.
-pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, u64, MemberIndexes<'a>> {
+pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, (u64, u64), MemberIndexes<'a>> {
     let indexes = MemberIndexes {
-        weight: MultiIndex::new(|&w| w, tg4::MEMBERS_KEY, "members__weight"),
+        weight: MultiIndex::new(
+            |&(w, h)| (w, -(h as i64)),
+            tg4::MEMBERS_KEY,
+            "members__weight",
+        ),
     };
     IndexedSnapshotMap::new(
         tg4::MEMBERS_KEY,

--- a/packages/voting-contract/src/multitest/suite.rs
+++ b/packages/voting-contract/src/multitest/suite.rs
@@ -43,6 +43,7 @@ impl SuiteBuilder {
         self.members.push(Member {
             addr: addr.to_owned(),
             weight,
+            start_height: 0, // FIXME?
         });
         self
     }
@@ -127,6 +128,7 @@ impl Suite {
             .map(|(addr, weight)| Member {
                 addr: (*addr).to_owned(),
                 weight: *weight,
+                start_height: 0, // FIXME?
             })
             .collect();
 


### PR DESCRIPTION
Closes #22.

For this to work properly, it was necessary to add a `start_height` field to the `Member` struct. So that it can be used for pagination. If not, pagination could fail, return repeated elements, or both.

This field can be made optional. As it is now, it needs to be set for "add member", but it will then be ignored on addition. Working on that extension now. Publishing as Draft in the mean time, so that you can take a look.

I personally think this is a nice tie-breaking mechanism. But perhaps, adding this is too much of a hassle for such a minor issue / detail.