### PR TITLE
Valset: metadata validation

### DIFF
--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -237,7 +237,7 @@ fn execute_update_metadata(
     metadata.validate()?;
     let moniker = metadata.moniker.clone();
 
-    operators().update(deps.storage, &info.sender, |info| match info {
+    operators().update(deps.storage, &info.sender, |op_info| match op_info {
         Some(mut old) => {
             old.metadata = metadata;
             Ok(old)

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -91,6 +91,7 @@ pub fn instantiate(
     for op in msg.initial_keys.into_iter() {
         let oper = deps.api.addr_validate(&op.operator)?;
         let pubkey: Ed25519Pubkey = op.validator_pubkey.try_into()?;
+        op.metadata.validate()?;
         let info = OperatorInfo {
             pubkey,
             metadata: op.metadata,
@@ -205,6 +206,8 @@ fn execute_register_validator_key(
     pubkey: Pubkey,
     metadata: ValidatorMetadata,
 ) -> Result<Response, ContractError> {
+    metadata.validate()?;
+
     let pubkey: Ed25519Pubkey = pubkey.try_into()?;
     let moniker = metadata.moniker.clone();
 
@@ -237,7 +240,7 @@ fn execute_update_metadata(
     metadata.validate()?;
     let moniker = metadata.moniker.clone();
 
-    operators().update(deps.storage, &info.sender, |op_info| match op_info {
+    operators().update(deps.storage, &info.sender, |info| match info {
         Some(mut old) => {
             old.metadata = metadata;
             Ok(old)

--- a/contracts/tgrade-valset/src/error.rs
+++ b/contracts/tgrade-valset/src/error.rs
@@ -69,8 +69,12 @@ pub enum ContractError {
     #[error("Jail did not yet expire")]
     JailDidNotExpire {},
 
-    #[error("Invalid metadata - {data} length must be {min}-256 characters")]
-    InvalidMetadata { data: String, min: usize },
+    #[error("Invalid metadata - {data} length must be {min}-{max} characters")]
+    InvalidMetadata {
+        data: String,
+        min: usize,
+        max: usize,
+    },
 }
 
 impl From<Ed25519PubkeyConversionError> for ContractError {

--- a/contracts/tgrade-valset/src/error.rs
+++ b/contracts/tgrade-valset/src/error.rs
@@ -36,9 +36,6 @@ pub enum ContractError {
     #[error("Scaling must be unset or greater than zero")]
     InvalidScaling {},
 
-    #[error("The moniker field must not be empty")]
-    InvalidMoniker {},
-
     #[error("Tendermint pubkey must be 32 bytes long")]
     InvalidPubkey {},
 
@@ -71,6 +68,9 @@ pub enum ContractError {
 
     #[error("Jail did not yet expire")]
     JailDidNotExpire {},
+
+    #[error("Invalid metadata - {data} length must be {min}-256 characters")]
+    InvalidMetadata { data: String, min: usize },
 }
 
 impl From<Ed25519PubkeyConversionError> for ContractError {

--- a/contracts/tgrade-valset/src/error.rs
+++ b/contracts/tgrade-valset/src/error.rs
@@ -71,7 +71,7 @@ pub enum ContractError {
 
     #[error("Invalid metadata - {data} length must be {min}-{max} characters")]
     InvalidMetadata {
-        data: String,
+        data: &'static str,
         min: usize,
         max: usize,
     },

--- a/contracts/tgrade-valset/src/error.rs
+++ b/contracts/tgrade-valset/src/error.rs
@@ -75,6 +75,9 @@ pub enum ContractError {
         min: usize,
         max: usize,
     },
+
+    #[error("Invalid metadata - website needs to start with http:// or https://")]
+    InvalidMetadataWebsitePrefix {},
 }
 
 impl From<Ed25519PubkeyConversionError> for ContractError {

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -287,7 +287,7 @@ impl ValidatorMetadata {
     pub fn validate(&self) -> Result<(), ContractError> {
         if self.moniker.len() < MIN_MONIKER_LENGTH || self.moniker.len() > MAX_METADATA_SIZE {
             return Err(ContractError::InvalidMetadata {
-                data: "moniker".to_owned(),
+                data: "moniker",
                 min: MIN_MONIKER_LENGTH,
                 max: MAX_METADATA_SIZE,
             });
@@ -295,7 +295,7 @@ impl ValidatorMetadata {
         if let Some(identity) = &self.identity {
             if identity.is_empty() || identity.len() > MAX_METADATA_SIZE {
                 return Err(ContractError::InvalidMetadata {
-                    data: "identity".to_owned(),
+                    data: "identity",
                     min: MIN_METADATA_SIZE,
                     max: MAX_METADATA_SIZE,
                 });
@@ -304,7 +304,7 @@ impl ValidatorMetadata {
         if let Some(website) = &self.website {
             if website.is_empty() || website.len() > MAX_METADATA_SIZE {
                 return Err(ContractError::InvalidMetadata {
-                    data: "website".to_owned(),
+                    data: "website",
                     min: MIN_METADATA_SIZE,
                     max: MAX_METADATA_SIZE,
                 });
@@ -313,7 +313,7 @@ impl ValidatorMetadata {
         if let Some(security_contract) = &self.security_contact {
             if security_contract.is_empty() || security_contract.len() > MAX_METADATA_SIZE {
                 return Err(ContractError::InvalidMetadata {
-                    data: "security_contract".to_owned(),
+                    data: "security_contract",
                     min: MIN_METADATA_SIZE,
                     max: MAX_METADATA_SIZE,
                 });
@@ -322,7 +322,7 @@ impl ValidatorMetadata {
         if let Some(details) = &self.details {
             if details.is_empty() || details.len() > MAX_METADATA_SIZE {
                 return Err(ContractError::InvalidMetadata {
-                    data: "details".to_owned(),
+                    data: "details",
                     min: MIN_METADATA_SIZE,
                     max: MAX_METADATA_SIZE,
                 });
@@ -573,7 +573,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "identity".to_owned(),
+                data: "identity",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE
             },
@@ -587,7 +587,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "website".to_owned(),
+                data: "website",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE,
             },
@@ -601,7 +601,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "security_contract".to_owned(),
+                data: "security_contract",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE,
             },
@@ -615,7 +615,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "details".to_owned(),
+                data: "details",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE,
             },
@@ -632,7 +632,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "identity".to_owned(),
+                data: "identity",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE
             },
@@ -646,7 +646,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "website".to_owned(),
+                data: "website",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE,
             },
@@ -660,7 +660,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "security_contract".to_owned(),
+                data: "security_contract",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE,
             },
@@ -674,7 +674,7 @@ mod test {
         let resp = meta.validate().unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "details".to_owned(),
+                data: "details",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE,
             },

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -279,8 +279,8 @@ pub struct ValidatorMetadata {
     pub details: Option<String>,
 }
 
-const MIN_MONIKER_LENGTH: usize = 3;
-const MIN_METADATA_SIZE: usize = 1;
+pub const MIN_MONIKER_LENGTH: usize = 3;
+pub const MIN_METADATA_SIZE: usize = 1;
 pub const MAX_METADATA_SIZE: usize = 256;
 
 impl ValidatorMetadata {
@@ -289,6 +289,7 @@ impl ValidatorMetadata {
             return Err(ContractError::InvalidMetadata {
                 data: "moniker".to_owned(),
                 min: MIN_MONIKER_LENGTH,
+                max: MAX_METADATA_SIZE,
             });
         }
         if let Some(identity) = &self.identity {
@@ -296,6 +297,7 @@ impl ValidatorMetadata {
                 return Err(ContractError::InvalidMetadata {
                     data: "identity".to_owned(),
                     min: MIN_METADATA_SIZE,
+                    max: MAX_METADATA_SIZE,
                 });
             }
         }
@@ -304,6 +306,7 @@ impl ValidatorMetadata {
                 return Err(ContractError::InvalidMetadata {
                     data: "website".to_owned(),
                     min: MIN_METADATA_SIZE,
+                    max: MAX_METADATA_SIZE,
                 });
             }
         }
@@ -312,6 +315,7 @@ impl ValidatorMetadata {
                 return Err(ContractError::InvalidMetadata {
                     data: "security_contract".to_owned(),
                     min: MIN_METADATA_SIZE,
+                    max: MAX_METADATA_SIZE,
                 });
             }
         }
@@ -320,6 +324,7 @@ impl ValidatorMetadata {
                 return Err(ContractError::InvalidMetadata {
                     data: "details".to_owned(),
                     min: MIN_METADATA_SIZE,
+                    max: MAX_METADATA_SIZE,
                 });
             }
         }
@@ -554,5 +559,126 @@ mod test {
         invalid.epoch_reward.denom = "".into();
         let err = invalid.validate().unwrap_err();
         assert_eq!(err, ContractError::InvalidRewardDenom {});
+    }
+
+    #[test]
+    fn validate_metadata() {
+        let meta = ValidatorMetadata {
+            moniker: "example".to_owned(),
+            identity: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+            website: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+            security_contact: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+            details: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "identity".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            identity: Some("identity".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "website".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE,
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            website: Some("website".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "security_contract".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE,
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            security_contact: Some("contract".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "details".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE,
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            identity: Some(String::new()),
+            website: Some(String::new()),
+            security_contact: Some(String::new()),
+            details: Some(String::new()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "identity".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            identity: Some("identity".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "website".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE,
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            website: Some("website".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "security_contract".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE,
+            },
+            resp
+        );
+
+        let meta = ValidatorMetadata {
+            security_contact: Some("contract".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(
+            ContractError::InvalidMetadata {
+                data: "details".to_owned(),
+                min: MIN_METADATA_SIZE,
+                max: MAX_METADATA_SIZE,
+            },
+            resp
+        );
     }
 }

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -308,6 +308,8 @@ impl ValidatorMetadata {
                     min: MIN_METADATA_SIZE,
                     max: MAX_METADATA_SIZE,
                 });
+            } else if !website.starts_with("https://") && !website.starts_with("http://") {
+                return Err(ContractError::InvalidMetadataWebsitePrefix {});
             }
         }
         if let Some(security_contract) = &self.security_contact {
@@ -595,7 +597,7 @@ mod test {
         );
 
         let meta = ValidatorMetadata {
-            website: Some("website".to_owned()),
+            website: Some("https://website".to_owned()),
             ..meta
         };
         let resp = meta.validate().unwrap_err();
@@ -654,7 +656,7 @@ mod test {
         );
 
         let meta = ValidatorMetadata {
-            website: Some("website".to_owned()),
+            website: Some("http://website".to_owned()),
             ..meta
         };
         let resp = meta.validate().unwrap_err();
@@ -680,5 +682,12 @@ mod test {
             },
             resp
         );
+
+        let meta = ValidatorMetadata {
+            website: Some("website".to_owned()),
+            ..meta
+        };
+        let resp = meta.validate().unwrap_err();
+        assert_eq!(ContractError::InvalidMetadataWebsitePrefix {}, resp);
     }
 }

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -11,6 +11,8 @@ use crate::error::ContractError;
 use crate::state::{DistributionContract, OperatorInfo, ValidatorInfo, ValidatorSlashing};
 use cosmwasm_std::{Addr, Api, BlockInfo, Coin, Decimal};
 
+const MIN_MONIKER_LENGTH: usize = 3;
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InstantiateMsg {
     /// Address allowed to jail, meant to be a OC voting contract. If `None`, then jailing is
@@ -92,60 +94,6 @@ pub struct InstantiateMsg {
     pub rewards_code_id: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct UnvalidatedDistributionContract {
-    /// The unvalidated address of the contract to which part of the reward tokens is sent to.
-    pub contract: String,
-    /// The ratio of total reward tokens for an epoch to be sent to that contract for further
-    /// distribution.
-    pub ratio: Decimal,
-}
-
-impl UnvalidatedDistributionContract {
-    fn validate(self, api: &dyn Api) -> Result<DistributionContract, ContractError> {
-        Ok(DistributionContract {
-            contract: api.addr_validate(&self.contract)?,
-            ratio: self.ratio,
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
-#[serde(transparent)]
-pub struct UnvalidatedDistributionContracts {
-    pub inner: Vec<UnvalidatedDistributionContract>,
-}
-
-impl UnvalidatedDistributionContracts {
-    /// Validates the addresses and the sum of ratios.
-    pub fn validate(self, api: &dyn Api) -> Result<Vec<DistributionContract>, ContractError> {
-        if self.sum_ratios() > Decimal::one() {
-            return Err(ContractError::InvalidRewardsRatio {});
-        }
-
-        self.inner.into_iter().map(|c| c.validate(api)).collect()
-    }
-
-    fn sum_ratios(&self) -> Decimal {
-        self.inner
-            .iter()
-            .map(|c| c.ratio)
-            .fold(Decimal::zero(), Decimal::add)
-    }
-}
-
-pub fn default_fee_percentage() -> Decimal {
-    Decimal::zero()
-}
-
-pub fn default_validators_reward_ratio() -> Decimal {
-    Decimal::one()
-}
-
-pub fn default_double_sign_slash() -> Decimal {
-    Decimal::percent(50)
-}
-
 impl InstantiateMsg {
     pub fn validate(&self) -> Result<(), ContractError> {
         if self.epoch_length == 0 {
@@ -168,54 +116,6 @@ impl InstantiateMsg {
             op.validate()?
         }
         Ok(())
-    }
-}
-
-/// Validator Metadata modeled after the Cosmos SDK staking module
-#[derive(
-    Serialize, Deserialize, Clone, Eq, PartialEq, Ord, PartialOrd, JsonSchema, Debug, Default,
-)]
-pub struct ValidatorMetadata {
-    /// The validator's name (required)
-    pub moniker: String,
-
-    /// The optional identity signature (ex. UPort or Keybase)
-    pub identity: Option<String>,
-
-    /// The validator's (optional) website
-    pub website: Option<String>,
-
-    /// The validator's (optional) security contact email
-    pub security_contact: Option<String>,
-
-    /// The validator's (optional) details
-    pub details: Option<String>,
-}
-
-const MIN_MONIKER_LENGTH: usize = 3;
-
-impl ValidatorMetadata {
-    pub fn validate(&self) -> Result<(), ContractError> {
-        if self.moniker.len() < MIN_MONIKER_LENGTH {
-            return Err(ContractError::InvalidMoniker {});
-        }
-        Ok(())
-    }
-}
-
-/// Maps an sdk address to a Tendermint pubkey.
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct OperatorInitInfo {
-    pub operator: String,
-    /// TODO: better name to specify this is the Tendermint pubkey for consensus?
-    pub validator_pubkey: Pubkey,
-    pub metadata: ValidatorMetadata,
-}
-
-impl OperatorInitInfo {
-    pub fn validate(&self) -> Result<(), ContractError> {
-        Ed25519Pubkey::try_from(&self.validator_pubkey)?;
-        self.metadata.validate()
     }
 }
 
@@ -304,6 +204,106 @@ pub enum QueryMsg {
 
     /// Returns cw_controllers::AdminResponse
     Admin {},
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct UnvalidatedDistributionContract {
+    /// The unvalidated address of the contract to which part of the reward tokens is sent to.
+    pub contract: String,
+    /// The ratio of total reward tokens for an epoch to be sent to that contract for further
+    /// distribution.
+    pub ratio: Decimal,
+}
+
+impl UnvalidatedDistributionContract {
+    fn validate(self, api: &dyn Api) -> Result<DistributionContract, ContractError> {
+        Ok(DistributionContract {
+            contract: api.addr_validate(&self.contract)?,
+            ratio: self.ratio,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[serde(transparent)]
+pub struct UnvalidatedDistributionContracts {
+    pub inner: Vec<UnvalidatedDistributionContract>,
+}
+
+impl UnvalidatedDistributionContracts {
+    /// Validates the addresses and the sum of ratios.
+    pub fn validate(self, api: &dyn Api) -> Result<Vec<DistributionContract>, ContractError> {
+        if self.sum_ratios() > Decimal::one() {
+            return Err(ContractError::InvalidRewardsRatio {});
+        }
+
+        self.inner.into_iter().map(|c| c.validate(api)).collect()
+    }
+
+    fn sum_ratios(&self) -> Decimal {
+        self.inner
+            .iter()
+            .map(|c| c.ratio)
+            .fold(Decimal::zero(), Decimal::add)
+    }
+}
+
+pub fn default_fee_percentage() -> Decimal {
+    Decimal::zero()
+}
+
+pub fn default_validators_reward_ratio() -> Decimal {
+    Decimal::one()
+}
+
+pub fn default_double_sign_slash() -> Decimal {
+    Decimal::percent(50)
+}
+
+/// Validator Metadata modeled after the Cosmos SDK staking module
+#[derive(
+    Serialize, Deserialize, Clone, Eq, PartialEq, Ord, PartialOrd, JsonSchema, Debug, Default,
+)]
+pub struct ValidatorMetadata {
+    /// The validator's name (required)
+    pub moniker: String,
+
+    /// The optional identity signature (ex. UPort or Keybase)
+    pub identity: Option<String>,
+
+    /// The validator's (optional) website
+    pub website: Option<String>,
+
+    /// The validator's (optional) security contact email
+    pub security_contact: Option<String>,
+
+    /// The validator's (optional) details
+    pub details: Option<String>,
+}
+
+impl ValidatorMetadata {
+    pub fn validate(&self) -> Result<(), ContractError> {
+        if self.moniker.len() < MIN_MONIKER_LENGTH {
+            return Err(ContractError::InvalidMoniker {});
+        }
+        Ok(())
+    }
+}
+
+/// Maps an sdk address to a Tendermint pubkey.
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct OperatorInitInfo {
+    pub operator: String,
+    /// TODO: better name to specify this is the Tendermint pubkey for consensus?
+    pub validator_pubkey: Pubkey,
+    pub metadata: ValidatorMetadata,
+}
+
+impl OperatorInitInfo {
+    pub fn validate(&self) -> Result<(), ContractError> {
+        Ed25519Pubkey::try_from(&self.validator_pubkey)?;
+        self.metadata.validate()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -11,8 +11,6 @@ use crate::error::ContractError;
 use crate::state::{DistributionContract, OperatorInfo, ValidatorInfo, ValidatorSlashing};
 use cosmwasm_std::{Addr, Api, BlockInfo, Coin, Decimal};
 
-const MIN_MONIKER_LENGTH: usize = 3;
-
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct InstantiateMsg {
     /// Address allowed to jail, meant to be a OC voting contract. If `None`, then jailing is
@@ -281,10 +279,49 @@ pub struct ValidatorMetadata {
     pub details: Option<String>,
 }
 
+const MIN_MONIKER_LENGTH: usize = 3;
+const MIN_METADATA_SIZE: usize = 1;
+pub const MAX_METADATA_SIZE: usize = 256;
+
 impl ValidatorMetadata {
     pub fn validate(&self) -> Result<(), ContractError> {
-        if self.moniker.len() < MIN_MONIKER_LENGTH {
-            return Err(ContractError::InvalidMoniker {});
+        if self.moniker.len() < MIN_MONIKER_LENGTH || self.moniker.len() > MAX_METADATA_SIZE {
+            return Err(ContractError::InvalidMetadata {
+                data: "moniker".to_owned(),
+                min: MIN_MONIKER_LENGTH,
+            });
+        }
+        if let Some(identity) = &self.identity {
+            if identity.is_empty() || identity.len() > MAX_METADATA_SIZE {
+                return Err(ContractError::InvalidMetadata {
+                    data: "identity".to_owned(),
+                    min: MIN_METADATA_SIZE,
+                });
+            }
+        }
+        if let Some(website) = &self.website {
+            if website.is_empty() || website.len() > MAX_METADATA_SIZE {
+                return Err(ContractError::InvalidMetadata {
+                    data: "website".to_owned(),
+                    min: MIN_METADATA_SIZE,
+                });
+            }
+        }
+        if let Some(security_contract) = &self.security_contact {
+            if security_contract.is_empty() || security_contract.len() > MAX_METADATA_SIZE {
+                return Err(ContractError::InvalidMetadata {
+                    data: "security_contract".to_owned(),
+                    min: MIN_METADATA_SIZE,
+                });
+            }
+        }
+        if let Some(details) = &self.details {
+            if details.is_empty() || details.len() > MAX_METADATA_SIZE {
+                return Err(ContractError::InvalidMetadata {
+                    data: "details".to_owned(),
+                    min: MIN_METADATA_SIZE,
+                });
+            }
         }
         Ok(())
     }

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -1,8 +1,10 @@
 use crate::error::ContractError;
-use crate::msg::{EpochResponse, ValidatorMetadata};
+use crate::msg::{
+    EpochResponse, ValidatorMetadata, MAX_METADATA_SIZE, MIN_METADATA_SIZE, MIN_MONIKER_LENGTH,
+};
 use crate::state::Config;
 
-use super::helpers::{assert_active_validators, assert_operators, members_init};
+use super::helpers::{addr_to_pubkey, assert_active_validators, assert_operators, members_init};
 use super::suite::SuiteBuilder;
 use assert_matches::assert_matches;
 use cosmwasm_std::{coin, Decimal};
@@ -177,60 +179,8 @@ fn update_metadata() {
     assert_eq!(
         ContractError::InvalidMetadata {
             data: "moniker".to_owned(),
-            min: 3
-        },
-        resp.downcast().unwrap()
-    );
-
-    // Ensure no metadata changed
-    let resp = suite.validator(members[0]).unwrap();
-    assert_eq!(resp.validator.unwrap().metadata, meta);
-
-    // Update with valid meta on non-member always fail
-    let resp = suite.update_metadata("invalid", &meta).unwrap_err();
-    assert_eq!(
-        ContractError::Unauthorized("No operator info found".to_owned()),
-        resp.downcast().unwrap()
-    );
-}
-
-#[test]
-fn try_to_update_else_metadata() {
-    let members = vec!["member1", "member2"];
-    let mut suite = SuiteBuilder::new()
-        .with_engagement(&members_init(&members, &[2]))
-        .with_operators(&members)
-        .build();
-
-    let meta = ValidatorMetadata {
-        moniker: "funny boy".to_owned(),
-        identity: Some("Secret identity".to_owned()),
-        website: Some("https://www.funny.boy.rs".to_owned()),
-        security_contact: Some("funny@boy.rs".to_owned()),
-        details: Some("Comedian".to_owned()),
-    };
-
-    suite.update_metadata(members[0], &meta).unwrap();
-
-    let resp = suite.validator(members[0]).unwrap();
-    assert_eq!(resp.validator.unwrap().metadata, meta);
-
-    let invalid_meta = ValidatorMetadata {
-        moniker: "".to_owned(),
-        identity: Some("Magic identity".to_owned()),
-        website: Some("https://www.empty.one.rs".to_owned()),
-        security_contact: Some("empty@one.rs".to_owned()),
-        details: Some("Ghost".to_owned()),
-    };
-
-    // Update with invalid meta (empty moniker) fails
-    let resp = suite
-        .update_metadata(members[0], &invalid_meta)
-        .unwrap_err();
-    assert_eq!(
-        ContractError::InvalidMetadata {
-            data: "moniker".to_owned(),
-            min: 3
+            min: MIN_MONIKER_LENGTH,
+            max: MAX_METADATA_SIZE,
         },
         resp.downcast().unwrap()
     );
@@ -317,5 +267,55 @@ fn list_validators_paginated() {
             (members[3], None),
             (members[4], None),
         ],
+    );
+}
+
+#[test]
+fn register_key_invalid_metadata() {
+    let members = vec!["member1"];
+
+    let mut suite = SuiteBuilder::new()
+        .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
+        .with_operators(&members)
+        .with_min_weight(5)
+        .build();
+
+    let meta = ValidatorMetadata {
+        moniker: "example".to_owned(),
+        identity: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        website: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        security_contact: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        details: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+    };
+    let pubkey = addr_to_pubkey(members[0]);
+    let resp = suite
+        .register_validator_key(members[0], pubkey.clone(), meta.clone())
+        .unwrap_err();
+    assert_eq!(
+        ContractError::InvalidMetadata {
+            data: "identity".to_owned(),
+            min: MIN_METADATA_SIZE,
+            max: MAX_METADATA_SIZE
+        },
+        resp.downcast().unwrap()
+    );
+
+    let meta = ValidatorMetadata {
+        identity: Some(String::new()),
+        website: Some(String::new()),
+        security_contact: Some(String::new()),
+        details: Some(String::new()),
+        ..meta
+    };
+    let resp = suite
+        .register_validator_key(members[0], pubkey, meta)
+        .unwrap_err();
+    assert_eq!(
+        ContractError::InvalidMetadata {
+            data: "identity".to_owned(),
+            min: MIN_METADATA_SIZE,
+            max: MAX_METADATA_SIZE
+        },
+        resp.downcast().unwrap()
     );
 }

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -319,3 +319,48 @@ fn register_key_invalid_metadata() {
         resp.downcast().unwrap()
     );
 }
+
+#[test]
+fn update_metadata_invalid_metadata() {
+    let members = vec!["member1"];
+
+    let mut suite = SuiteBuilder::new()
+        .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
+        .with_operators(&members)
+        .with_min_weight(5)
+        .build();
+
+    let meta = ValidatorMetadata {
+        moniker: "example".to_owned(),
+        identity: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        website: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        security_contact: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        details: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+    };
+    let resp = suite.update_metadata(members[0], &meta).unwrap_err();
+    assert_eq!(
+        ContractError::InvalidMetadata {
+            data: "identity".to_owned(),
+            min: MIN_METADATA_SIZE,
+            max: MAX_METADATA_SIZE
+        },
+        resp.downcast().unwrap()
+    );
+
+    let meta = ValidatorMetadata {
+        identity: Some(String::new()),
+        website: Some(String::new()),
+        security_contact: Some(String::new()),
+        details: Some(String::new()),
+        ..meta
+    };
+    let resp = suite.update_metadata(members[0], &meta).unwrap_err();
+    assert_eq!(
+        ContractError::InvalidMetadata {
+            data: "identity".to_owned(),
+            min: MIN_METADATA_SIZE,
+            max: MAX_METADATA_SIZE
+        },
+        resp.downcast().unwrap()
+    );
+}

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -178,7 +178,7 @@ fn update_metadata() {
         .unwrap_err();
     assert_eq!(
         ContractError::InvalidMetadata {
-            data: "moniker".to_owned(),
+            data: "moniker",
             min: MIN_MONIKER_LENGTH,
             max: MAX_METADATA_SIZE,
         },
@@ -277,7 +277,7 @@ fn register_key_invalid_metadata() {
     let mut suite = SuiteBuilder::new()
         .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
         .with_operators(&members)
-        .with_min_weight(5)
+        .with_min_points(5)
         .build();
 
     let meta = ValidatorMetadata {
@@ -293,7 +293,7 @@ fn register_key_invalid_metadata() {
         .unwrap_err();
     assert_eq!(
         ContractError::InvalidMetadata {
-            data: "identity".to_owned(),
+            data: "identity",
             min: MIN_METADATA_SIZE,
             max: MAX_METADATA_SIZE
         },
@@ -312,7 +312,7 @@ fn register_key_invalid_metadata() {
         .unwrap_err();
     assert_eq!(
         ContractError::InvalidMetadata {
-            data: "identity".to_owned(),
+            data: "identity",
             min: MIN_METADATA_SIZE,
             max: MAX_METADATA_SIZE
         },
@@ -327,7 +327,7 @@ fn update_metadata_invalid_metadata() {
     let mut suite = SuiteBuilder::new()
         .with_engagement(&members_init(&members, &[2, 3, 5, 8, 13, 21]))
         .with_operators(&members)
-        .with_min_weight(5)
+        .with_min_points(5)
         .build();
 
     let meta = ValidatorMetadata {
@@ -340,7 +340,7 @@ fn update_metadata_invalid_metadata() {
     let resp = suite.update_metadata(members[0], &meta).unwrap_err();
     assert_eq!(
         ContractError::InvalidMetadata {
-            data: "identity".to_owned(),
+            data: "identity",
             min: MIN_METADATA_SIZE,
             max: MAX_METADATA_SIZE
         },
@@ -357,7 +357,7 @@ fn update_metadata_invalid_metadata() {
     let resp = suite.update_metadata(members[0], &meta).unwrap_err();
     assert_eq!(
         ContractError::InvalidMetadata {
-            data: "identity".to_owned(),
+            data: "identity",
             min: MIN_METADATA_SIZE,
             max: MAX_METADATA_SIZE
         },
@@ -386,7 +386,7 @@ mod instantiate {
         let admin = "steakhouse owner".to_owned();
         let msg = tg4_stake::msg::InstantiateMsg {
             denom: "james bond denom".to_owned(),
-            tokens_per_weight: Uint128::new(10),
+            tokens_per_point: Uint128::new(10),
             min_bond: Uint128::new(1),
             unbonding_period: 1234,
             admin: Some(admin.clone()),
@@ -419,7 +419,7 @@ mod instantiate {
         let msg = InstantiateMsg {
             admin: None,
             membership: stake_addr.into(),
-            min_weight: 1,
+            min_points: 1,
             max_validators: 120,
             epoch_length: 10,
             epoch_reward: coin(1, "denom"),
@@ -437,7 +437,7 @@ mod instantiate {
             .unwrap_err();
         assert_eq!(
             ContractError::InvalidMetadata {
-                data: "details".to_owned(),
+                data: "details",
                 min: MIN_METADATA_SIZE,
                 max: MAX_METADATA_SIZE
             },

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -174,7 +174,13 @@ fn update_metadata() {
     let resp = suite
         .update_metadata(members[0], &invalid_meta)
         .unwrap_err();
-    assert_eq!(ContractError::InvalidMoniker {}, resp.downcast().unwrap());
+    assert_eq!(
+        ContractError::InvalidMetadata {
+            data: "moniker".to_owned(),
+            min: 3
+        },
+        resp.downcast().unwrap()
+    );
 
     // Ensure no metadata changed
     let resp = suite.validator(members[0]).unwrap();
@@ -221,7 +227,13 @@ fn try_to_update_else_metadata() {
     let resp = suite
         .update_metadata(members[0], &invalid_meta)
         .unwrap_err();
-    assert_eq!(ContractError::InvalidMoniker {}, resp.downcast().unwrap());
+    assert_eq!(
+        ContractError::InvalidMetadata {
+            data: "moniker".to_owned(),
+            min: 3
+        },
+        resp.downcast().unwrap()
+    );
 
     // Ensure no metadata changed
     let resp = suite.validator(members[0]).unwrap();

--- a/contracts/tgrade-valset/src/multitest/double_sign.rs
+++ b/contracts/tgrade-valset/src/multitest/double_sign.rs
@@ -2,10 +2,11 @@ use cosmwasm_std::coin;
 use cosmwasm_std::{Binary, Decimal};
 use tg_bindings::{Ed25519Pubkey, Evidence, EvidenceType, ToAddress, Validator};
 
-use super::helpers::{addr_to_pubkey, assert_operators, mock_pubkey};
+use super::helpers::{addr_to_pubkey, assert_operators};
 use super::suite::SuiteBuilder;
 use crate::msg::{JailingPeriod, ValidatorMetadata};
 use crate::multitest::helpers::members_init;
+use crate::test_helpers::mock_pubkey;
 
 use std::convert::TryFrom;
 

--- a/contracts/tgrade-valset/src/multitest/helpers.rs
+++ b/contracts/tgrade-valset/src/multitest/helpers.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::Binary;
 use tg_bindings::Pubkey;
 
-use crate::msg::{JailingPeriod, OperatorResponse, ValidatorMetadata};
+use crate::msg::{JailingPeriod, OperatorResponse, ValidatorMetadata, MAX_METADATA_SIZE};
 use crate::state::ValidatorInfo;
 
 // Converts address to valid public key
@@ -10,20 +10,23 @@ pub fn addr_to_pubkey(addr: &str) -> Pubkey {
     Pubkey::Ed25519(Binary((*addr).as_bytes().to_vec()))
 }
 
-pub fn mock_pubkey(base: &[u8]) -> Pubkey {
-    const ED25519_PUBKEY_LENGTH: usize = 32;
-
-    let copies = (ED25519_PUBKEY_LENGTH / base.len()) + 1;
-    let mut raw = base.repeat(copies);
-    raw.truncate(ED25519_PUBKEY_LENGTH);
-    Pubkey::Ed25519(Binary(raw))
-}
-
-pub fn mock_metadata(seed: &str) -> ValidatorMetadata {
+pub fn invalid_metadata_short(seed: &str) -> ValidatorMetadata {
     ValidatorMetadata {
         moniker: seed.into(),
-        details: Some(format!("I'm really {}", seed)),
-        ..ValidatorMetadata::default()
+        identity: Some(String::new()),
+        website: Some(String::new()),
+        security_contact: Some(String::new()),
+        details: Some(String::new()),
+    }
+}
+
+pub fn invalid_metadata_long(seed: &str) -> ValidatorMetadata {
+    ValidatorMetadata {
+        moniker: seed.into(),
+        identity: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        website: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        security_contact: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
+        details: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
     }
 }
 

--- a/contracts/tgrade-valset/src/multitest/helpers.rs
+++ b/contracts/tgrade-valset/src/multitest/helpers.rs
@@ -1,33 +1,13 @@
 use cosmwasm_std::Binary;
 use tg_bindings::Pubkey;
 
-use crate::msg::{JailingPeriod, OperatorResponse, ValidatorMetadata, MAX_METADATA_SIZE};
+use crate::msg::{JailingPeriod, OperatorResponse};
 use crate::state::ValidatorInfo;
 
 // Converts address to valid public key
 // Requires addr to be exactly 32 bytes long, panics otherwise
 pub fn addr_to_pubkey(addr: &str) -> Pubkey {
     Pubkey::Ed25519(Binary((*addr).as_bytes().to_vec()))
-}
-
-pub fn invalid_metadata_short(seed: &str) -> ValidatorMetadata {
-    ValidatorMetadata {
-        moniker: seed.into(),
-        identity: Some(String::new()),
-        website: Some(String::new()),
-        security_contact: Some(String::new()),
-        details: Some(String::new()),
-    }
-}
-
-pub fn invalid_metadata_long(seed: &str) -> ValidatorMetadata {
-    ValidatorMetadata {
-        moniker: seed.into(),
-        identity: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
-        website: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
-        security_contact: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
-        details: Some((0..MAX_METADATA_SIZE + 1).map(|_| "X").collect::<String>()),
-    }
 }
 
 pub fn members_init<'m>(members: &[&'m str], weights: &[u64]) -> Vec<(&'m str, u64)> {

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -1,5 +1,6 @@
-use super::helpers::{addr_to_pubkey, mock_metadata, mock_pubkey};
+use super::helpers::addr_to_pubkey;
 use crate::state::Config;
+use crate::test_helpers::{mock_metadata, mock_pubkey};
 use crate::{msg::*, state::ValidatorInfo};
 use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::{

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -24,7 +24,7 @@ pub fn contract_engagement() -> Box<dyn Contract<TgradeMsg>> {
     Box::new(contract)
 }
 
-fn contract_stake() -> Box<dyn Contract<TgradeMsg>> {
+pub fn contract_stake() -> Box<dyn Contract<TgradeMsg>> {
     let contract = ContractWrapper::new(
         tg4_stake::contract::execute,
         tg4_stake::contract::instantiate,

--- a/contracts/tgrade-valset/tests/integration.rs
+++ b/contracts/tgrade-valset/tests/integration.rs
@@ -15,6 +15,7 @@ use tg_bindings::Pubkey;
 
 use tgrade_valset::msg::ExecuteMsg;
 use tgrade_valset::state::ValidatorInfo;
+use tgrade_valset::test_helpers::mock_pubkey;
 
 // Copied from test_helpers
 // returns a list of addresses that are set in the tg4-stake contract
@@ -48,16 +49,6 @@ fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQu
             ..Default::default()
         },
     )
-}
-
-const ED25519_PUBKEY_LENGTH: usize = 32;
-
-// creates a valid pubkey from a seed
-fn mock_pubkey(base: &[u8]) -> Pubkey {
-    let copies = (ED25519_PUBKEY_LENGTH / base.len()) + 1;
-    let mut raw = base.repeat(copies);
-    raw.truncate(ED25519_PUBKEY_LENGTH);
-    Pubkey::Ed25519(Binary(raw))
 }
 
 static WASM: &[u8] =


### PR DESCRIPTION
closes https://github.com/confio/poe-contracts/issues/66

In `msg.rs` file I only expanded `ValidatorMetadata::validate()` method and added two more consts. Rest of changes is shuffling some stuff up or down, so for example `QueryMsg` is directly under `InstantiateMsg` enums, instead somewhere in the middle of the file...