### PR TITLE
Valset config contract names

### DIFF
--- a/contracts/tgrade-valset/README.md
+++ b/contracts/tgrade-valset/README.md
@@ -70,7 +70,7 @@ managed by `tgrade-valset`. It is assumed to be the `tg4-engagement` contract, b
 in reality it should just support the proper API, which is then used by `tgrade-valset`
 (which is just a subset of `tg4-engagement`).
 
-During valset instantiation, the rewards distribution contract is instantiated using
+During valset instantiation, the rewards distribution contract, called `validator_group`, is instantiated using
 the message:
 
 ```json
@@ -81,22 +81,19 @@ the message:
 }
 ```
 
-The code id of the stored rewards distribution contract is sent to valset in its instantiation message
-(`rewards_code_id` field). The assigned address of the rewards distribution contract would be
+The code id of the stored validator group contract is sent to valset in its instantiation message
+(`validator_group_code_id` field). The assigned address of the validator group contract would be
 emitted with a `wasm` event:
 
 ```json
 {
   "_contract_addr": "valset_addr",
   "action": "tgrade-valset_instantiation",
-  "rewards_contract": "rewards_contract_addr"
+  "validator_group": "validator_group_addr"
 }
 ```
 
-Additionally, the rewards contract address can be queried at any time using the
-`rewards_distribution_contract {}` query.
-
-At every epoch end, rewards would be sent to the rewards distribution contract
+At every epoch end, rewards would be sent to the validator group contract
 with the execution message:
 
 ```json
@@ -253,7 +250,7 @@ pub struct InstantiateMsg {
     /// ```
     ///
     /// This contract has to support all the `RewardsDistribution` messages
-    pub rewards_code_id: u64,
+    pub validator_group_id: u64,
 }
 ```
 

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -74,7 +74,7 @@ pub fn instantiate(
         double_sign_slash_ratio: msg.double_sign_slash_ratio,
         distribution_contracts,
         // Will be overwritten in reply for rewards contract instantiation
-        rewards_contract: Addr::unchecked(""),
+        validator_group: Addr::unchecked(""),
     };
     CONFIG.save(deps.storage, &cfg)?;
 
@@ -724,7 +724,7 @@ fn end_block(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     };
 
     let res = res.add_submessage(SubMsg::new(WasmMsg::Execute {
-        contract_addr: cfg.rewards_contract.to_string(),
+        contract_addr: cfg.validator_group.to_string(),
         msg: to_binary(&update_members)?,
         funds: vec![],
     }));
@@ -1012,7 +1012,7 @@ pub fn rewards_instantiate_reply(
 
     let addr = deps.api.addr_validate(&res.contract_address)?;
     CONFIG.update(deps.storage, |mut config| -> StdResult<_> {
-        config.rewards_contract = addr.clone();
+        config.validator_group = addr.clone();
         Ok(config)
     })?;
 

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -113,7 +113,7 @@ pub fn instantiate(
 
     let instantiate_rewards_msg = WasmMsg::Instantiate {
         admin: msg.admin,
-        code_id: msg.rewards_code_id,
+        code_id: msg.validator_group_code_id,
         msg: to_binary(&rewards_init)?,
         funds: vec![],
         label: format!("rewards_distribution_{}", env.contract.address),

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -1017,7 +1017,7 @@ pub fn rewards_instantiate_reply(
     })?;
 
     let data = InstantiateResponse {
-        rewards_contract: addr,
+        validator_group: addr,
     };
 
     let resp = Response::new().set_data(to_binary(&data)?);

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -479,7 +479,7 @@ pub enum RewardsDistribution {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct InstantiateResponse {
-    pub rewards_contract: Addr,
+    pub validator_group: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -89,7 +89,7 @@ pub struct InstantiateMsg {
     /// ```
     ///
     /// This contract has to support all the `RewardsDistribution` messages
-    pub rewards_code_id: u64,
+    pub validator_group_code_id: u64,
 }
 
 impl InstantiateMsg {
@@ -518,7 +518,7 @@ mod test {
             auto_unjail: false,
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: UnvalidatedDistributionContracts::default(),
-            rewards_code_id: 0,
+            validator_group_code_id: 0,
         };
         proper.validate().unwrap();
 

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -39,7 +39,7 @@ fn initialization() {
             distribution_contracts: vec![],
             // This one it is basically assumed is set correctly. Other tests tests if behavior
             // of relation between those contract is correct
-            rewards_contract: config.rewards_contract.clone(),
+            validator_group: config.rewards_contract.clone(),
         }
     );
 

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -39,7 +39,7 @@ fn initialization() {
             distribution_contracts: vec![],
             // This one it is basically assumed is set correctly. Other tests tests if behavior
             // of relation between those contract is correct
-            validator_group: config.rewards_contract.clone(),
+            validator_group: config.validator_group.clone(),
         }
     );
 

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -429,7 +429,7 @@ mod instantiate {
             auto_unjail: false,
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: UnvalidatedDistributionContracts::default(),
-            rewards_code_id: 1,
+            validator_group_code_id: 1,
         };
 
         let err = app

--- a/contracts/tgrade-valset/src/multitest/stake.rs
+++ b/contracts/tgrade-valset/src/multitest/stake.rs
@@ -34,7 +34,7 @@ fn init_and_query_state() {
             auto_unjail: false,
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: vec![],
-            validator_group: cfg.rewards_contract.clone(),
+            validator_group: cfg.validator_group.clone(),
         }
     );
 

--- a/contracts/tgrade-valset/src/multitest/stake.rs
+++ b/contracts/tgrade-valset/src/multitest/stake.rs
@@ -34,7 +34,7 @@ fn init_and_query_state() {
             auto_unjail: false,
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: vec![],
-            rewards_contract: cfg.rewards_contract.clone(),
+            validator_group: cfg.rewards_contract.clone(),
         }
     );
 

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -404,7 +404,7 @@ impl SuiteBuilder {
             operators: operators.into_iter().map(|o| o.operator).collect(),
             epoch_length: self.epoch_length,
             denom,
-            rewards_contract: resp.rewards_contract,
+            rewards_contract: resp.validator_group,
         }
     }
 }

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -404,7 +404,7 @@ impl SuiteBuilder {
             operators: operators.into_iter().map(|o| o.operator).collect(),
             epoch_length: self.epoch_length,
             denom,
-            rewards_contract: resp.validator_group,
+            validator_group: resp.validator_group,
         }
     }
 }
@@ -432,7 +432,7 @@ pub struct Suite {
     /// Reward denom
     denom: String,
     /// Rewards distribution contract address
-    rewards_contract: Addr,
+    validator_group: Addr,
 }
 
 impl Suite {
@@ -620,7 +620,7 @@ impl Suite {
     pub fn withdraw_validation_reward(&mut self, executor: &str) -> AnyResult<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(executor),
-            self.rewards_contract.clone(),
+            self.validator_group.clone(),
             &tg4_engagement::msg::ExecuteMsg::WithdrawRewards {
                 owner: None,
                 receiver: None,

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -349,7 +349,7 @@ impl SuiteBuilder {
                     distribution_contracts: UnvalidatedDistributionContracts {
                         inner: distribution_contract_instantiation_info,
                     },
-                    rewards_code_id: engagement_id,
+                    validator_group_code_id: engagement_id,
                 },
                 &[],
                 "valset",

--- a/contracts/tgrade-valset/src/rewards.rs
+++ b/contracts/tgrade-valset/src/rewards.rs
@@ -63,7 +63,7 @@ pub fn pay_block_rewards(
     // After rewarding all non-validators, the remainder goes to validators.
     if reward_pool > Uint128::zero() {
         messages.push(SubMsg::new(WasmMsg::Execute {
-            contract_addr: config.rewards_contract.to_string(),
+            contract_addr: config.validator_group.to_string(),
             msg: to_binary(&RewardsDistribution::DistributeRewards {})?,
             funds: coins(reward_pool.into(), &block_reward.denom),
         }));

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -51,8 +51,8 @@ pub struct Config {
     /// rewards contract.
     pub distribution_contracts: Vec<DistributionContract>,
 
-    /// Address of contract for rewards distribution.
-    pub rewards_contract: Addr,
+    /// Address of contract for validator group voting.
+    pub validator_group: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/tgrade-valset/src/test_valset_stake.rs
+++ b/contracts/tgrade-valset/src/test_valset_stake.rs
@@ -175,7 +175,7 @@ fn init_and_query_state() {
             auto_unjail: false,
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: vec![],
-            rewards_contract: cfg.rewards_contract.clone(),
+            validator_group: cfg.validator_group.clone(),
         }
     );
 

--- a/contracts/tgrade-valset/src/test_valset_stake.rs
+++ b/contracts/tgrade-valset/src/test_valset_stake.rs
@@ -102,7 +102,7 @@ fn init_msg(
     stake_addr: &str,
     max_validators: u32,
     min_weight: u64,
-    rewards_code_id: u64,
+    validator_group_code_id: u64,
 ) -> InstantiateMsg {
     let members = addrs(PREREGISTER_MEMBERS)
         .into_iter()
@@ -121,7 +121,7 @@ fn init_msg(
         auto_unjail: false,
         double_sign_slash_ratio: Decimal::percent(50),
         distribution_contracts: UnvalidatedDistributionContracts::default(),
-        rewards_code_id,
+        validator_group_code_id,
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/confio/tgrade-contracts/issues/320.

The full renames are:

- `rewards_contract` -> `validator_group`.
- `rewards_code_id` -> `validator_group_code_id` (for consistency).