### PR TITLE
Release 0.6.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-beta1...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.0-rc2...HEAD)
+
+## [v0.6.0-rc2](https://github.com/confio/poe-contracts/tree/v0.6.0-rc2) (2022-02-03)
 
 **Breaking changes:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1581,7 +1581,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,7 +2,7 @@
 
 This guide lists API changes between releases of *PoE* contracts.
 
-## 0.6.0-beta1 -> 0.6.0-rc1
+## 0.6.0-beta1 -> 0.6.0-rc2
 
 ### tg4-engagement
 
@@ -61,9 +61,13 @@ Messages changes:
 * rewards_code_id field on instantiate message renamed to validator_group_code_id
 * rewards_contract field on InstantiateReponse message renamed to validator_group
 
-
 State changes:
 
 * `min_weight` field on `config` item renamed to `min_points`
 * rewards_contract field on config item renamed to validator_group
 
+### voting-contract
+
+Messages changes:
+
+* total_weight field on Proposal message renamed to total_points

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.6.0-rc1" }
-tg-utils = { version = "0.6.0-rc1", path = "../../packages/utils" }
-tg-bindings = { version = "0.6.0-rc1", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-rc2" }
+tg-utils = { version = "0.6.0-rc2", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.0-rc2", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }
 cw-multi-test = { version = "0.11.0" }
-tg-bindings-test = { version = "0.6.0-rc1", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.6.0-rc2", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw20 = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.6.0-rc1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-rc1" }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc1" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-rc2" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-rc2" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc2" }
 cosmwasm-std = "1.0.0-beta"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -46,8 +46,8 @@ cw-multi-test = { version = "0.11.0" }
 cosmwasm-schema = { version = "1.0.0-beta" }
 # version's workaround for issue with cyclic dependencies during cargo publish
 # https://github.com/rust-lang/cargo/issues/4242
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc1", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.6.0-rc1", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc2", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.6.0-rc2", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.11.0"
 cw2 = "0.11.0"
 cw-controllers = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg4 = { path = "../../packages/tg4", version = "0.6.0-rc1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-rc1" }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc1" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-rc2" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-rc2" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc2" }
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -22,15 +22,15 @@ tg3 = { path = "../../packages/tg3", version = "0.6.0-beta1" }
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-rc1" }
-tg-voting-contract = { version = "0.6.0-rc1", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc1", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc2" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-rc2" }
+tg-voting-contract = { version = "0.6.0-rc2", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc2", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-rc1" }
-tg4 = { path = "../../packages/tg4", version = "0.6.0-rc1" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-rc2" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-rc2" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/confio/poe-contracts"
@@ -25,7 +25,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta"
 cw-storage-plus = "0.11.0"
-tg-bindings = { version = "0.6.0-rc1", path = "../../packages/bindings" }
+tg-bindings = { version = "0.6.0-rc2", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -22,9 +22,9 @@ tg3 = { path = "../../packages/tg3", version = "0.6.0-beta1" }
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc1" }
-tg-utils = { path = "../../packages/utils", version = "0.6.0-rc1" }
-tg-voting-contract = { version = "0.6.0-rc1", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.0-rc2" }
+tg-utils = { path = "../../packages/utils", version = "0.6.0-rc2" }
+tg-voting-contract = { version = "0.6.0-rc2", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
 cw-storage-plus = "0.11.0"
-tg-bindings-test = { version = "0.6.0-rc1", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.6.0-rc1", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.6.0-rc1", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.6.0-rc1" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc1", features = ["library"] }
+tg-bindings-test = { version = "0.6.0-rc2", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.6.0-rc2", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.6.0-rc2", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-rc2" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc2", features = ["library"] }

--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -327,7 +327,7 @@ mod tests {
                         threshold: Decimal::percent(40),
                         allow_end_early: true,
                     },
-                    total_weight: 20,
+                    total_points: 20,
                     votes: Votes {
                         yes: 20,
                         no: 0,
@@ -371,7 +371,7 @@ mod tests {
                         threshold: Decimal::percent(40),
                         allow_end_early: true,
                     },
-                    total_weight: 20,
+                    total_points: 20,
                     votes: Votes {
                         yes: 20,
                         no: 0,
@@ -417,7 +417,7 @@ mod tests {
                         threshold: Decimal::percent(40),
                         allow_end_early: true,
                     },
-                    total_weight: 20,
+                    total_points: 20,
                     votes: Votes {
                         yes: 20,
                         no: 0,
@@ -463,7 +463,7 @@ mod tests {
                         threshold: Decimal::percent(40),
                         allow_end_early: true,
                     },
-                    total_weight: 20,
+                    total_points: 20,
                     votes: Votes {
                         yes: 20,
                         no: 0,
@@ -512,7 +512,7 @@ mod tests {
                         threshold: Decimal::percent(40),
                         allow_end_early: true,
                     },
-                    total_weight: 20,
+                    total_points: 20,
                     votes: Votes {
                         yes: 20,
                         no: 0,
@@ -564,7 +564,7 @@ mod tests {
                         threshold: Decimal::percent(40),
                         allow_end_early: true,
                     },
-                    total_weight: 20,
+                    total_points: 20,
                     votes: Votes {
                         yes: 20,
                         no: 0,

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -29,9 +29,9 @@ integration = ["bech32", "cosmwasm-vm"]
 [dependencies]
 cw-utils = { version = "0.11.0" }
 cw2 = { version = "0.11.0" }
-tg4 = { path = "../../packages/tg4", version = "0.6.0-rc1" }
-tg-bindings = { version = "0.6.0-rc1", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.0-rc1", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.6.0-rc2" }
+tg-bindings = { version = "0.6.0-rc2", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.0-rc2", path = "../../packages/utils" }
 cw-controllers = { version = "0.11.0" }
 cw-storage-plus = { version = "0.11.0" }
 cosmwasm-std = { version = "1.0.0-beta4" }
@@ -46,10 +46,10 @@ cosmwasm-vm = { version = "1.0.0-beta4", optional = true, default-features = fal
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta4" }
 cw-multi-test = "0.11.0"
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc1" }
-tg4-stake = { path = "../tg4-stake", version = "0.6.0-rc1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.0-rc2" }
+tg4-stake = { path = "../tg4-stake", version = "0.6.0-rc2" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-rc1" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-rc2" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.11.0"
 cw-storage-plus = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.6.0-rc1", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.0-rc1", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.0-rc2", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.0-rc2", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
-tg-bindings-test = { version = "0.6.0-rc1", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.6.0-rc2", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.6.0-rc1", path = "../bindings" }
+tg-bindings = { version = "0.6.0-rc2", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta"
-tg-voting-contract = { path = "../voting-contract", version = "0.6.0-rc1" }
+tg-voting-contract = { path = "../voting-contract", version = "0.6.0-rc2" }

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.6.0-rc1" }
+tg-bindings = { path = "../bindings", version = "0.6.0-rc2" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.11.0"
 cw2 = "0.11.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.6.0-rc1" }
-tg-bindings = { path = "../bindings", version = "0.6.0-rc1" }
+tg4 = { path = "../tg4", version = "0.6.0-rc2" }
+tg-bindings = { path = "../bindings", version = "0.6.0-rc2" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -17,9 +17,9 @@ cw-storage-plus = "0.11.0"
 cosmwasm-std = "1.0.0-beta"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.6.0-rc1" }
-tg-bindings = { path = "../bindings", version = "0.6.0-rc1" }
-tg-utils = { version = "0.6.0-rc1", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.6.0-rc2" }
+tg-bindings = { path = "../bindings", version = "0.6.0-rc2" }
+tg-utils = { version = "0.6.0-rc2", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta"
 cw-multi-test = "0.11.0"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-rc1" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.0-rc1", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.0-rc2" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.0-rc2", features = ["library"] }

--- a/packages/voting-contract/src/msg.rs
+++ b/packages/voting-contract/src/msg.rs
@@ -1,31 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use tg3::Vote;
-
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct ProposalCreationResponse {
     pub proposal_id: u64,
-}
-
-// TODO: Remove all underneath when cw-plus equivalent is updated about proposal_id field
-// https://github.com/CosmWasm/cw-plus/issues/647
-/// Returns the vote (opinion as well as weight counted) as well as
-/// the address of the voter who submitted it
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct VoteInfo {
-    pub proposal_id: u64,
-    pub voter: String,
-    pub vote: Vote,
-    pub weight: u64,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct VoteListResponse {
-    pub votes: Vec<VoteInfo>,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-pub struct VoteResponse {
-    pub vote: Option<VoteInfo>,
 }

--- a/packages/voting-contract/src/multitest/proposing.rs
+++ b/packages/voting-contract/src/multitest/proposing.rs
@@ -41,7 +41,7 @@ fn proposal_creation() {
             status: Status::Open,
             expires: expected_expiration,
             rules,
-            total_weight: 4,
+            total_points: 4,
             votes: Votes::yes(1),
         }
     )

--- a/packages/voting-contract/src/multitest/queries.rs
+++ b/packages/voting-contract/src/multitest/queries.rs
@@ -1,9 +1,8 @@
 use cosmwasm_std::Decimal;
-use tg3::{Status, Vote};
+use tg3::{Status, Vote, VoteInfo};
 use tg_utils::Expiration;
 
 use super::contracts::voting::Proposal;
-use crate::msg::VoteInfo;
 use crate::multitest::suite::{get_proposal_id, SuiteBuilder};
 use crate::state::{ProposalInfo, ProposalResponse, RulesBuilder, Votes};
 
@@ -69,7 +68,7 @@ fn query_proposal() {
             status: Status::Open,
             expires: expected_expiration,
             rules: rules.clone(),
-            total_weight: 10,
+            total_points: 10,
             votes: Votes {
                 yes: 1,
                 no: 0,
@@ -95,7 +94,7 @@ fn query_proposal() {
             status: Status::Open,
             expires: expected_expiration,
             rules: rules.clone(),
-            total_weight: 10,
+            total_points: 10,
             votes: Votes {
                 yes: 1,
                 no: 2,
@@ -118,7 +117,7 @@ fn query_proposal() {
             status: Status::Rejected,
             expires: expected_expiration,
             rules,
-            total_weight: 10,
+            total_points: 10,
             votes: Votes {
                 yes: 1,
                 no: 2,
@@ -156,7 +155,7 @@ fn query_individual_votes() {
             proposal_id,
             voter: "alice".to_string(),
             vote: Vote::Yes,
-            weight: 1
+            points: 1
         })
     );
 
@@ -168,7 +167,7 @@ fn query_individual_votes() {
             proposal_id,
             voter: "bob".to_owned(),
             vote: Vote::No,
-            weight: 2
+            points: 2
         })
     );
 
@@ -261,13 +260,13 @@ fn list_votes() {
                 proposal_id,
                 voter: "alice".to_string(),
                 vote: Vote::Yes,
-                weight: 1
+                points: 1
             },
             VoteInfo {
                 proposal_id,
                 voter: "bob".to_string(),
                 vote: Vote::No,
-                weight: 2
+                points: 2
             }
         ]
     )
@@ -303,19 +302,19 @@ fn list_votes_pagination() {
                 proposal_id,
                 voter: "alice".to_string(),
                 vote: Vote::Yes,
-                weight: 1
+                points: 1
             },
             VoteInfo {
                 proposal_id,
                 voter: "bob".to_string(),
                 vote: Vote::No,
-                weight: 2
+                points: 2
             },
             VoteInfo {
                 proposal_id,
                 voter: "carol".to_string(),
                 vote: Vote::Abstain,
-                weight: 3
+                points: 3
             }
         ]
     );
@@ -328,13 +327,13 @@ fn list_votes_pagination() {
                 proposal_id,
                 voter: "carol".to_string(),
                 vote: Vote::Abstain,
-                weight: 3
+                points: 3
             },
             VoteInfo {
                 proposal_id,
                 voter: "dave".to_string(),
                 vote: Vote::Veto,
-                weight: 4
+                points: 4
             },
         ]
     );
@@ -372,19 +371,19 @@ fn list_votes_by_voter() {
                 proposal_id,
                 voter: "bob".to_string(),
                 vote: Vote::No,
-                weight: 2
+                points: 2
             },
             VoteInfo {
                 proposal_id: proposal_id2,
                 voter: "bob".to_string(),
                 vote: Vote::Yes,
-                weight: 2
+                points: 2
             },
             VoteInfo {
                 proposal_id: proposal_id3,
                 voter: "bob".to_string(),
                 vote: Vote::Abstain,
-                weight: 2
+                points: 2
             }
         ]
     );
@@ -426,13 +425,13 @@ fn list_votes_by_voter_with_pagination() {
                 proposal_id,
                 voter: "bob".to_string(),
                 vote: Vote::No,
-                weight: 2
+                points: 2
             },
             VoteInfo {
                 proposal_id: proposal_id2,
                 voter: "bob".to_string(),
                 vote: Vote::Yes,
-                weight: 2
+                points: 2
             },
         ]
     );
@@ -443,7 +442,7 @@ fn list_votes_by_voter_with_pagination() {
             proposal_id: proposal_id3,
             voter: "bob".to_string(),
             vote: Vote::Abstain,
-            weight: 2
+            points: 2
         },]
     );
     let votes = suite.list_votes_by_voter("bob", 2, None).unwrap();
@@ -454,13 +453,13 @@ fn list_votes_by_voter_with_pagination() {
                 proposal_id: proposal_id3,
                 voter: "bob".to_string(),
                 vote: Vote::Abstain,
-                weight: 2
+                points: 2
             },
             VoteInfo {
                 proposal_id: proposal_id4,
                 voter: "bob".to_string(),
                 vote: Vote::Yes,
-                weight: 2
+                points: 2
             },
         ]
     )

--- a/packages/voting-contract/src/multitest/suite.rs
+++ b/packages/voting-contract/src/multitest/suite.rs
@@ -7,13 +7,14 @@ use anyhow::Result as AnyResult;
 use cosmwasm_std::{Addr, StdResult};
 use cw_multi_test::{AppResponse, Executor};
 use derivative::Derivative;
-use tg3::{Vote, VoterDetail, VoterListResponse, VoterResponse};
+use tg3::{
+    Vote, VoteInfo, VoteListResponse, VoteResponse, VoterDetail, VoterListResponse, VoterResponse,
+};
 
 use tg4::Member;
 use tg_bindings_test::TgradeApp;
 
 use crate::{
-    msg::{VoteInfo, VoteListResponse, VoteResponse},
     state::{
         ProposalInfo, ProposalListResponse, ProposalResponse, RulesBuilder,
         TextProposalListResponse, VotingRules,

--- a/packages/voting-contract/src/state.rs
+++ b/packages/voting-contract/src/state.rs
@@ -32,8 +32,8 @@ pub struct Proposal<P> {
     pub status: Status,
     /// pass requirements
     pub rules: VotingRules,
-    // the total weight when the proposal started (used to calculate percentages)
-    pub total_weight: u64,
+    // the total number of points when the proposal started (used to calculate percentages)
+    pub total_points: u64,
     // summary of existing votes
     pub votes: Votes,
 }
@@ -81,7 +81,7 @@ impl<P> Proposal<P> {
         } = self.rules;
 
         // we always require the quorum
-        if self.votes.total() < votes_needed(self.total_weight, quorum) {
+        if self.votes.total() < votes_needed(self.total_points, quorum) {
             return false;
         }
         if self.expires.is_expired(block) {
@@ -91,7 +91,7 @@ impl<P> Proposal<P> {
         } else if allow_end_early {
             // If not expired, we must assume all non-votes will be cast as No.
             // We compare threshold against the total weight (minus abstain).
-            let possible_opinions = self.total_weight - self.votes.abstain;
+            let possible_opinions = self.total_points - self.votes.abstain;
             self.votes.yes >= votes_needed(possible_opinions, threshold)
         } else {
             false
@@ -112,7 +112,7 @@ pub struct ProposalResponse<P> {
     pub status: Status,
     pub expires: Expiration,
     pub rules: VotingRules,
-    pub total_weight: u64,
+    pub total_points: u64,
     pub votes: Votes,
 }
 
@@ -257,7 +257,7 @@ fn votes_needed(weight: u64, percentage: Decimal) -> u64 {
 // stored under the key that voted
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Ballot {
-    pub weight: u64,
+    pub points: u64,
     pub vote: Vote,
 }
 


### PR DESCRIPTION
Since cw3 was replaced with local tg3, I could easily remove extra `VoteInfo` implementation that is required in tgrade-contracts.
So this new-extra release will make update in tgrade much easier.
Plus extra naming fixes.