### PR TITLE
Update to cw-plus 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta4"
+version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f472c0bfd584a4510702537d0b65c5331095e76099586a12f749fd69afda9c5e"
+checksum = "e7e4338d8e9934effa4594f139ce4e5f4b426796b70e2d53bb7e8605e9adf68c"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bfeaf55f8dba5646cc3daddce17cd23a60f8e0c3fbacbe6735d287d7a6e33a"
+checksum = "2e125c834c186f20b48106917329fae6459b41715fd1c6a4f4be4a49e4185c49"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b44e3ccc6ead7e8c0ecc682e8ab634ce1dec8a2ac97b7b44e84477695adc55"
+checksum = "c5363a1903f8e5dd480240fdf007177fc11b3511097a06c5601a885cf619cdd5"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
+checksum = "c087ff98fb0475db4c2b5298a5fd12b2848d2854b39d1115d930ee6da24d1eed"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef842a1792e4285beff7b3b518705f760fa4111dc1e296e53f3e92d1ef7f6220"
+checksum = "e3396c7aff5a0e3fb6dcc6cc89f56862c1d212b40d93ed725a6962955b1887ff"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d81d7c359d6c1fba3aa83dad7ec6f999e512571380ae62f81257c3db569743"
+checksum = "4f8a6500c396e33f6a7b05d35a5124eb3e394cdb6ca901f7e88332870407896c"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9671d7edef5608acaf5b2f1e473ee3f501eced2cd4f7392e2106c8cf02ba0720"
+checksum = "413911037f6b0106ae37ca82352f9131939ccc995aade435df47a5baf2c815f2"
 dependencies = [
  "cosmwasm-std",
  "cw-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "schemars",
  "serde",
  "tg-bindings",
+ "tg-bindings-test",
  "tg-utils",
  "tg4",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41445666e3f6284c72f569b2240bb52d0add94bb448e169d30ae28fe000cfaeb"
+checksum = "f22da7845e99e5a277523d61c19bda3171ec3dd1084b9ca6ebac6b2fd0cdf084"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -20,10 +20,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = "0.11.1"
-cw2 = "0.11.1"
-cw-controllers = "0.11.1"
-cw-storage-plus = "0.11.1"
+cw-utils = "0.12.1"
+cw2 = "0.12.1"
+cw-controllers = "0.12.1"
+cw-storage-plus = "0.12.1"
 tg4 = { path = "../../packages/tg4", version = "0.6.2" }
 tg-utils = { version = "0.6.2", path = "../../packages/utils" }
 tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
@@ -34,7 +34,7 @@ thiserror = { version = "1.0.21" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta5" }
-cw-multi-test = { version = "0.11.1" }
+cw-multi-test = { version = "0.12.1" }
 tg-bindings-test = { version = "0.6.2", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     MessageInfo, Order, StdResult, Timestamp, Uint128,
 };
 use cw2::set_contract_version;
-use cw_storage_plus::{Bound, PrimaryKey};
+use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
 use tg4::{
     HooksResponse, Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
@@ -825,7 +825,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let members: StdResult<Vec<_>> = members()
         .range(deps.storage, start, None, Order::Ascending)
@@ -848,7 +848,13 @@ fn list_members_by_points(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|m| Bound::exclusive((m.points, m.addr.as_str()).joined_key()));
+    let start = start_after
+        .map(|m| {
+            deps.api
+                .addr_validate(&m.addr)
+                .map(|addr| Bound::exclusive((m.points, addr)))
+        })
+        .transpose()?;
     let members: StdResult<Vec<_>> = members()
         .idx
         .points

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, to_binary, Addr, BankMsg, Binary, Coin, Decimal, Deps, DepsMut, Empty, Env, Event,
-    MessageInfo, Order, StdResult, Timestamp, Uint128,
+    coin, to_binary, Addr, BankMsg, Binary, Coin, CustomQuery, Decimal, Deps, DepsMut, Empty, Env,
+    Event, MessageInfo, Order, StdResult, Timestamp, Uint128,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
@@ -37,8 +37,8 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 // Note, you can use StdResult in some functions where you do not
 // make use of the custom errors
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn instantiate(
-    deps: DepsMut,
+pub fn instantiate<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -62,8 +62,8 @@ pub fn instantiate(
 // create is the instantiation logic with set_contract_version removed so it can more
 // easily be imported in other contracts
 #[allow(clippy::too_many_arguments)]
-pub fn create(
-    mut deps: DepsMut,
+pub fn create<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     admin: Option<String>,
     members_list: Vec<Member>,
     preauths_hooks: u64,
@@ -119,8 +119,8 @@ pub fn create(
 
 // And declare a custom Error variant for the ones where you will want to make use of it
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn execute(
-    deps: DepsMut,
+pub fn execute<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -149,8 +149,8 @@ pub fn execute(
     }
 }
 
-pub fn execute_add_points(
-    mut deps: DepsMut,
+pub fn execute_add_points<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     addr: String,
@@ -184,8 +184,8 @@ pub fn execute_add_points(
     Ok(res)
 }
 
-pub fn execute_add_hook(
-    deps: DepsMut,
+pub fn execute_add_hook<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     hook: String,
 ) -> Result<Response, ContractError> {
@@ -205,8 +205,8 @@ pub fn execute_add_hook(
     Ok(res)
 }
 
-pub fn execute_remove_hook(
-    deps: DepsMut,
+pub fn execute_remove_hook<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     hook: String,
 ) -> Result<Response, ContractError> {
@@ -229,8 +229,8 @@ pub fn execute_remove_hook(
     Ok(resp)
 }
 
-pub fn execute_update_members(
-    mut deps: DepsMut,
+pub fn execute_update_members<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     add: Vec<Member>,
@@ -253,8 +253,8 @@ pub fn execute_update_members(
     Ok(res)
 }
 
-pub fn execute_distribute_rewards(
-    deps: DepsMut,
+pub fn execute_distribute_rewards<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     sender: Option<String>,
@@ -309,8 +309,8 @@ pub fn execute_distribute_rewards(
     Ok(resp)
 }
 
-pub fn execute_withdraw_rewards(
-    deps: DepsMut,
+pub fn execute_withdraw_rewards<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     owner: Option<String>,
     receiver: Option<String>,
@@ -360,8 +360,8 @@ pub fn execute_withdraw_rewards(
     Ok(resp)
 }
 
-pub fn execute_delegate_withdrawal(
-    deps: DepsMut,
+pub fn execute_delegate_withdrawal<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     delegated: String,
 ) -> Result<Response, ContractError> {
@@ -390,8 +390,8 @@ pub fn execute_delegate_withdrawal(
 }
 
 /// Adds new slasher to contract
-pub fn execute_add_slasher(
-    deps: DepsMut,
+pub fn execute_add_slasher<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     slasher: String,
 ) -> Result<Response, ContractError> {
@@ -410,8 +410,8 @@ pub fn execute_add_slasher(
 }
 
 /// Removes slasher from contract
-pub fn execute_remove_slasher(
-    deps: DepsMut,
+pub fn execute_remove_slasher<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     slasher: String,
 ) -> Result<Response, ContractError> {
@@ -436,8 +436,8 @@ pub fn execute_remove_slasher(
 }
 
 /// Slashes engagement points from address
-pub fn execute_slash(
-    mut deps: DepsMut,
+pub fn execute_slash<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     addr: String,
@@ -493,8 +493,8 @@ pub fn execute_slash(
 }
 
 /// Calculates withdrawable_rewards from distribution and adjustment info.
-pub fn withdrawable_rewards(
-    deps: Deps,
+pub fn withdrawable_rewards<Q: CustomQuery>(
+    deps: Deps<Q>,
     owner: &Addr,
     distribution: &Distribution,
     adjustment: &WithdrawAdjustment,
@@ -514,8 +514,8 @@ pub fn withdrawable_rewards(
     Ok(coin(amount, &distribution.denom))
 }
 
-pub fn sudo_add_member(
-    mut deps: DepsMut,
+pub fn sudo_add_member<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     env: Env,
     add: Member,
 ) -> Result<Response, ContractError> {
@@ -534,8 +534,8 @@ pub fn sudo_add_member(
 }
 
 // the logic from execute_update_members extracted for easier import
-pub fn update_members(
-    mut deps: DepsMut,
+pub fn update_members<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     height: u64,
     to_add: Vec<Member>,
     to_remove: Vec<String>,
@@ -583,8 +583,8 @@ pub fn update_members(
 /// `shares_per_point` is current value from `SHARES_PER_POINT` - not loaded in function, to
 /// avoid multiple queries on bulk updates.
 /// `diff` is the points change
-pub fn apply_points_correction(
-    deps: DepsMut,
+pub fn apply_points_correction<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     addr: &Addr,
     shares_per_point: u128,
     diff: i128,
@@ -606,7 +606,11 @@ pub fn apply_points_correction(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractError> {
+pub fn sudo<Q: CustomQuery>(
+    deps: DepsMut<Q>,
+    env: Env,
+    msg: SudoMsg,
+) -> Result<Response, ContractError> {
     match msg {
         SudoMsg::UpdateMember(member) => sudo_add_member(deps, env, member),
         SudoMsg::PrivilegeChange(PrivilegeChangeMsg::Promoted {}) => privilege_promote(deps),
@@ -615,7 +619,7 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> Result<Response, ContractE
     }
 }
 
-fn privilege_promote(deps: DepsMut) -> Result<Response, ContractError> {
+fn privilege_promote<Q: CustomQuery>(deps: DepsMut<Q>) -> Result<Response, ContractError> {
     if HALFLIFE.load(deps.storage)?.halflife.is_some() {
         let msgs = request_privileges(&[Privilege::EndBlocker]);
         Ok(Response::new().add_submessages(msgs))
@@ -628,7 +632,7 @@ fn points_reduction(points: u64) -> u64 {
     points - (points / 2)
 }
 
-fn end_block(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
+fn end_block<Q: CustomQuery>(mut deps: DepsMut<Q>, env: Env) -> Result<Response, ContractError> {
     let resp = Response::new();
 
     // If duration of half life added to timestamp of last applied
@@ -693,7 +697,7 @@ fn end_block(mut deps: DepsMut, env: Env) -> Result<Response, ContractError> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query<Q: CustomQuery>(deps: Deps<Q>, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     use QueryMsg::*;
     match msg {
         Member {
@@ -732,12 +736,16 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-fn query_total_points(deps: Deps) -> StdResult<TotalPointsResponse> {
+fn query_total_points<Q: CustomQuery>(deps: Deps<Q>) -> StdResult<TotalPointsResponse> {
     let points = TOTAL.load(deps.storage)?;
     Ok(TotalPointsResponse { points })
 }
 
-fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<MemberResponse> {
+fn query_member<Q: CustomQuery>(
+    deps: Deps<Q>,
+    addr: String,
+    height: Option<u64>,
+) -> StdResult<MemberResponse> {
     let addr = deps.api.addr_validate(&addr)?;
     let points = match height {
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
@@ -746,7 +754,10 @@ fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<Memb
     Ok(MemberResponse { points })
 }
 
-pub fn query_withdrawable_rewards(deps: Deps, owner: String) -> StdResult<RewardsResponse> {
+pub fn query_withdrawable_rewards<Q: CustomQuery>(
+    deps: Deps<Q>,
+    owner: String,
+) -> StdResult<RewardsResponse> {
     // Not checking address, as if it is invalid it is guaranteed not to appear in maps, so
     // `withdrawable_rewards` would return error itself.
     let owner = Addr::unchecked(&owner);
@@ -763,7 +774,10 @@ pub fn query_withdrawable_rewards(deps: Deps, owner: String) -> StdResult<Reward
     Ok(RewardsResponse { rewards })
 }
 
-pub fn query_undistributed_rewards(deps: Deps, env: Env) -> StdResult<RewardsResponse> {
+pub fn query_undistributed_rewards<Q: CustomQuery>(
+    deps: Deps<Q>,
+    env: Env,
+) -> StdResult<RewardsResponse> {
     let distribution = DISTRIBUTION.load(deps.storage)?;
     let balance = deps
         .querier
@@ -778,14 +792,17 @@ pub fn query_undistributed_rewards(deps: Deps, env: Env) -> StdResult<RewardsRes
     })
 }
 
-pub fn query_distributed_rewards(deps: Deps) -> StdResult<RewardsResponse> {
+pub fn query_distributed_rewards<Q: CustomQuery>(deps: Deps<Q>) -> StdResult<RewardsResponse> {
     let distribution = DISTRIBUTION.load(deps.storage)?;
     Ok(RewardsResponse {
         rewards: coin(distribution.distributed_total.into(), &distribution.denom),
     })
 }
 
-pub fn query_delegated(deps: Deps, owner: String) -> StdResult<DelegatedResponse> {
+pub fn query_delegated<Q: CustomQuery>(
+    deps: Deps<Q>,
+    owner: String,
+) -> StdResult<DelegatedResponse> {
     let owner = deps.api.addr_validate(&owner)?;
 
     let delegated = WITHDRAW_ADJUSTMENT
@@ -795,7 +812,7 @@ pub fn query_delegated(deps: Deps, owner: String) -> StdResult<DelegatedResponse
     Ok(DelegatedResponse { delegated })
 }
 
-fn query_halflife(deps: Deps) -> StdResult<HalflifeResponse> {
+fn query_halflife<Q: CustomQuery>(deps: Deps<Q>) -> StdResult<HalflifeResponse> {
     let Halflife {
         halflife,
         last_applied: last_halflife,
@@ -818,8 +835,8 @@ fn query_halflife(deps: Deps) -> StdResult<HalflifeResponse> {
 const MAX_LIMIT: u32 = 100;
 const DEFAULT_LIMIT: u32 = 30;
 
-fn list_members(
-    deps: Deps,
+fn list_members<Q: CustomQuery>(
+    deps: Deps<Q>,
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
@@ -842,8 +859,8 @@ fn list_members(
     Ok(MemberListResponse { members: members? })
 }
 
-fn list_members_by_points(
-    deps: Deps,
+fn list_members_by_points<Q: CustomQuery>(
+    deps: Deps<Q>,
     start_after: Option<Member>,
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -897,12 +897,12 @@ mod tests {
 
     use crate::i128::Int128;
 
-    use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
+    use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{from_slice, Api, OwnedDeps, Querier, StdError, Storage};
     use cw_controllers::AdminError;
     use cw_storage_plus::Map;
-    use std::marker::PhantomData;
     use tg4::{member_key, TOTAL_KEY};
+    use tg_bindings_test::mock_deps_tgrade;
     use tg_utils::{HookError, PreauthError};
 
     const INIT_ADMIN: &str = "ADMIN";
@@ -912,15 +912,6 @@ mod tests {
     const USER2_POINTS: u64 = 6;
     const USER3: &str = "USER3";
     const HALFLIFE: u64 = 180 * 24 * 60 * 60;
-
-    fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, TgradeQuery> {
-        OwnedDeps {
-            storage: MockStorage::default(),
-            api: MockApi::default(),
-            querier: MockQuerier::default(),
-            custom_query_type: PhantomData,
-        }
-    }
 
     fn mock_env_height(height_offset: u64) -> Env {
         let mut env = mock_env();
@@ -952,7 +943,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // it worked, let's query the state
@@ -999,7 +990,7 @@ mod tests {
 
     #[test]
     fn try_member_queries() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         let member1 = query_member(deps.as_ref(), USER1.into(), None).unwrap();
@@ -1068,7 +1059,7 @@ mod tests {
 
     #[test]
     fn try_list_members_by_points() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         let members = list_members_by_points(deps.as_ref(), None, None)
@@ -1129,7 +1120,7 @@ mod tests {
 
     #[test]
     fn try_halflife_queries() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         let HalflifeInfo {
@@ -1155,7 +1146,7 @@ mod tests {
 
     #[test]
     fn try_halflife_query_when_no_halflife() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let msg = InstantiateMsg {
             admin: Some(INIT_ADMIN.into()),
             members: vec![
@@ -1182,7 +1173,7 @@ mod tests {
 
     #[test]
     fn handle_non_utf8_in_members_list() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // make sure we get 2 members as expected, no error
@@ -1235,7 +1226,7 @@ mod tests {
 
     #[test]
     fn add_new_remove_old_member() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // add a new one and remove existing one
@@ -1276,7 +1267,7 @@ mod tests {
     #[test]
     fn add_old_remove_new_member() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // add a new one and remove existing one
@@ -1297,7 +1288,7 @@ mod tests {
     #[test]
     fn add_and_remove_same_member() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // USER1 is updated and remove in the same call, we should remove this an add member3
@@ -1323,7 +1314,7 @@ mod tests {
 
     #[test]
     fn sudo_add_new_member() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // add a new member
@@ -1358,7 +1349,7 @@ mod tests {
 
     #[test]
     fn sudo_update_existing_member() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // update an existing member
@@ -1394,7 +1385,7 @@ mod tests {
     #[test]
     fn add_remove_hooks() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
@@ -1471,7 +1462,7 @@ mod tests {
 
     #[test]
     fn hooks_fire() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
@@ -1536,7 +1527,7 @@ mod tests {
     #[test]
     fn raw_queries_work() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         // get total from raw key
@@ -1556,7 +1547,7 @@ mod tests {
 
     #[test]
     fn halflife_workflow() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
         let mut env = mock_env();
 
@@ -1604,7 +1595,7 @@ mod tests {
 
         #[test]
         fn add_to_existing_member() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut());
 
             let env = mock_env();
@@ -1617,7 +1608,7 @@ mod tests {
 
         #[test]
         fn add_to_nonexisting_member() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut());
 
             let env = mock_env();
@@ -1632,7 +1623,7 @@ mod tests {
 
     #[test]
     fn slash_nonexisting_user() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut());
 
         let user1 = Addr::unchecked(USER1);

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -1,16 +1,18 @@
 use crate::error::ContractError;
 use crate::msg::*;
 use anyhow::Result as AnyResult;
-use cosmwasm_std::{Addr, Coin, CosmosMsg, Decimal, StdResult};
+use cosmwasm_std::{Addr, Coin, CosmosMsg, CustomQuery, Decimal, StdResult};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use derivative::Derivative;
+use serde::de::DeserializeOwned;
 use tg4::{Member, MemberListResponse};
-use tg_bindings::{TgradeMsg, TgradeQuery};
+use tg_bindings::TgradeMsg;
 use tg_bindings_test::TgradeApp;
 use tg_utils::Duration;
 
-fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(
+fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -10,7 +10,7 @@ use tg_bindings_test::TgradeApp;
 use tg_utils::Duration;
 
 fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
-    let contract = ContractWrapper::::new(
+    let contract = ContractWrapper::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -1,18 +1,16 @@
 use crate::error::ContractError;
 use crate::msg::*;
 use anyhow::Result as AnyResult;
-use cosmwasm_std::{Addr, Coin, CosmosMsg, CustomQuery, Decimal, StdResult};
+use cosmwasm_std::{Addr, Coin, CosmosMsg, Decimal, StdResult};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use derivative::Derivative;
-use serde::de::DeserializeOwned;
 use tg4::{Member, MemberListResponse};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::TgradeApp;
 use tg_utils::Duration;
 
-fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -10,7 +10,7 @@ use tg_bindings_test::TgradeApp;
 use tg_utils::Duration;
 
 fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(
+    let contract = ContractWrapper::::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -5,12 +5,12 @@ use cosmwasm_std::{Addr, Coin, CosmosMsg, Decimal, StdResult};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use derivative::Derivative;
 use tg4::{Member, MemberListResponse};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::TgradeApp;
 use tg_utils::Duration;
 
-pub fn contract_engagement() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -26,12 +26,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = "0.11.1"
-cw2 = "0.11.1"
-cw4 = "0.11.1"
+cw-utils = "0.12.1"
+cw2 = "0.12.1"
+cw4 = "0.12.1"
 tg4 = { version = "0.6.2", path = "../../packages/tg4" }
-cw-controllers = "0.11.1"
-cw-storage-plus = "0.11.1"
+cw-controllers = "0.12.1"
+cw-storage-plus = "0.12.1"
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tg4-group/src/contract.rs
+++ b/contracts/tg4-group/src/contract.rs
@@ -189,7 +189,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let members = MEMBERS
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -42,10 +42,8 @@ rust_decimal_macros = { version = "1.16", default-features = false }
 cosmwasm-vm = { version = "1.0.0-beta5", optional = true }
 
 [dev-dependencies]
-cw-multi-test = { version = "0.12.1" }
 cosmwasm-schema = { version = "1.0.0-beta5" }
-# version's workaround for issue with cyclic dependencies during cargo publish
-# https://github.com/rust-lang/cargo/issues/4242
+cw-multi-test = { version = "0.12.1" }
 tg4-engagement = { path = "../tg4-engagement", version = "0.6.2", features = ["library"] }
 tg4-stake = { path = "../tg4-stake", version = "0.6.2", features = ["library"] }
 

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -23,10 +23,10 @@ library = []
 benches = [ "cosmwasm-vm" ]
 
 [dependencies]
-cw-utils = "0.11.1"
-cw2 = "0.11.1"
-cw20 = "0.11.1"
-cw-storage-plus = "0.11.1"
+cw-utils = "0.12.1"
+cw2 = "0.12.1"
+cw20 = "0.12.1"
+cw-storage-plus = "0.12.1"
 tg4 = { path = "../../packages/tg4", version = "0.6.2" }
 tg-utils = { path = "../../packages/utils", version = "0.6.2" }
 tg-bindings = { path = "../../packages/bindings", version = "0.6.2" }
@@ -42,7 +42,7 @@ rust_decimal_macros = { version = "1.16", default-features = false }
 cosmwasm-vm = { version = "1.0.0-beta5", optional = true }
 
 [dev-dependencies]
-cw-multi-test = { version = "0.11.1" }
+cw-multi-test = { version = "0.12.1" }
 cosmwasm-schema = { version = "1.0.0-beta5" }
 # version's workaround for issue with cyclic dependencies during cargo publish
 # https://github.com/rust-lang/cargo/issues/4242

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
 };
 
 use cw2::set_contract_version;
-use cw_storage_plus::{Bound, PrimaryKey};
+use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
 
 use tg_bindings::TgradeMsg;
@@ -415,7 +415,7 @@ fn list_members(
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let members: StdResult<Vec<_>> = members()
         .range(deps.storage, start, None, Order::Ascending)
@@ -438,7 +438,13 @@ fn list_members_by_points(
     limit: Option<u32>,
 ) -> StdResult<MemberListResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.map(|m| Bound::exclusive((m.points, m.addr).joined_key()));
+    let start = start_after
+        .map(|m| {
+            deps.api
+                .addr_validate(&m.addr)
+                .map(|addr| Bound::exclusive((m.points, addr)))
+        })
+        .transpose()?;
     let members: StdResult<Vec<_>> = members()
         .idx
         .points

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -35,3 +35,4 @@ itertools = "0.10"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta5" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2" }

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -20,10 +20,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = "0.11.1"
-cw2 = "0.11.1"
-cw-controllers = "0.11.1"
-cw-storage-plus = "0.11.1"
+cw-utils = "0.12.1"
+cw2 = "0.12.1"
+cw-controllers = "0.12.1"
+cw-storage-plus = "0.12.1"
 tg4 = { path = "../../packages/tg4", version = "0.6.2" }
 tg-utils = { path = "../../packages/utils", version = "0.6.2" }
 tg-bindings = { path = "../../packages/bindings", version = "0.6.2" }

--- a/contracts/tg4-stake/src/claim.rs
+++ b/contracts/tg4-stake/src/claim.rs
@@ -5,7 +5,9 @@ use itertools::Itertools;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, BlockInfo, Decimal, Deps, Order, StdResult, Storage, Uint128};
+use cosmwasm_std::{
+    Addr, BlockInfo, CustomQuery, Decimal, Deps, Order, StdResult, Storage, Uint128,
+};
 use cw_storage_plus::{
     Bound, CwIntKey, Index, IndexList, IndexedMap, MultiIndex, PrefixBound, PrimaryKey,
 };
@@ -239,9 +241,9 @@ impl<'a> Claims<'a> {
         Ok(total_slashed)
     }
 
-    pub fn query_claims(
+    pub fn query_claims<Q: CustomQuery>(
         &self,
-        deps: Deps,
+        deps: Deps<Q>,
         address: Addr,
         limit: Option<u32>,
         start_after: Option<Expiration>,

--- a/contracts/tg4-stake/src/claim.rs
+++ b/contracts/tg4-stake/src/claim.rs
@@ -247,7 +247,7 @@ impl<'a> Claims<'a> {
         start_after: Option<Expiration>,
     ) -> StdResult<Vec<Claim>> {
         let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-        // FIXME: Prefix-generated bounds are still untyped(!)
+        // FIXME: IndexedMap prefix-generated bounds are still untyped(!)
         let start = start_after.map(|s| Bound::ExclusiveRaw(s.as_key().to_cw_bytes().into()));
 
         self.claims

--- a/contracts/tg4-stake/src/claim.rs
+++ b/contracts/tg4-stake/src/claim.rs
@@ -8,9 +8,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{
     Addr, BlockInfo, CustomQuery, Decimal, Deps, Order, StdResult, Storage, Uint128,
 };
-use cw_storage_plus::{
-    Bound, CwIntKey, Index, IndexList, IndexedMap, MultiIndex, PrefixBound, PrimaryKey,
-};
+use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, MultiIndex, PrefixBound};
 use tg_utils::Expiration;
 
 // settings for pagination
@@ -125,9 +123,7 @@ impl<'a> Claims<'a> {
             .range_raw(
                 storage,
                 None,
-                Some(Bound::inclusive(
-                    Expiration::now(block).as_key().joined_key(),
-                )),
+                Some(Bound::inclusive(Expiration::now(block).as_key())),
                 Order::Ascending,
             );
 
@@ -249,8 +245,7 @@ impl<'a> Claims<'a> {
         start_after: Option<Expiration>,
     ) -> StdResult<Vec<Claim>> {
         let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-        // FIXME: IndexedMap prefix-generated bounds are still untyped(!)
-        let start = start_after.map(|s| Bound::ExclusiveRaw(s.as_key().to_cw_bytes().into()));
+        let start = start_after.map(|s| Bound::exclusive(s.as_key()));
 
         self.claims
             .prefix(&address)

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -600,17 +600,17 @@ pub fn migrate(
 #[cfg(test)]
 mod tests {
     use crate::claim::Claim;
-    use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
+    use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::{
-        from_slice, CosmosMsg, OverflowError, OverflowOperation, OwnedDeps, StdError, Storage,
+        from_slice, CosmosMsg, OverflowError, OverflowOperation, StdError, Storage,
     };
-    use std::marker::PhantomData;
     use tg4::{member_key, TOTAL_KEY};
     use tg_utils::{Expiration, HookError, PreauthError, SlasherError};
 
     use crate::error::ContractError;
 
     use super::*;
+    use tg_bindings_test::mock_deps_tgrade;
 
     const INIT_ADMIN: &str = "juan";
     const USER1: &str = "user1";
@@ -620,15 +620,6 @@ mod tests {
     const TOKENS_PER_POINT: Uint128 = Uint128::new(1_000);
     const MIN_BOND: Uint128 = Uint128::new(5_000);
     const UNBONDING_DURATION: u64 = 100;
-
-    fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, TgradeQuery> {
-        OwnedDeps {
-            storage: MockStorage::default(),
-            api: MockApi::default(),
-            querier: MockQuerier::default(),
-            custom_query_type: PhantomData,
-        }
-    }
 
     fn default_instantiate(deps: DepsMut<TgradeQuery>) {
         do_instantiate(deps, TOKENS_PER_POINT, MIN_BOND, UNBONDING_DURATION, 0)
@@ -699,7 +690,7 @@ mod tests {
 
     #[test]
     fn proper_instantiation() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         // it worked, let's query the state
@@ -726,7 +717,7 @@ mod tests {
 
     #[test]
     fn unbonding_period_query_works() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         let raw = query(deps.as_ref(), mock_env(), QueryMsg::UnbondingPeriod {}).unwrap();
@@ -798,7 +789,7 @@ mod tests {
 
     #[test]
     fn bond_stake_adds_membership() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
         let height = mock_env().block.height;
 
@@ -828,7 +819,7 @@ mod tests {
 
     #[test]
     fn try_member_queries() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -896,7 +887,7 @@ mod tests {
 
     #[test]
     fn try_list_members_by_points() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         bond(deps.as_mut(), 11_000, 6_500, 5_000, 1);
@@ -971,7 +962,7 @@ mod tests {
 
     #[test]
     fn unbond_stake_update_membership() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
         let height = mock_env().block.height;
 
@@ -1016,7 +1007,7 @@ mod tests {
     #[test]
     fn raw_queries_work() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
         // Set values as (11, 6, None)
         bond(deps.as_mut(), 11_000, 6_000, 0, 1);
@@ -1050,7 +1041,7 @@ mod tests {
 
     #[test]
     fn unbond_claim_workflow() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         // create some data
@@ -1234,7 +1225,7 @@ mod tests {
     #[test]
     fn add_remove_hooks() {
         // add will over-write and remove have no effect
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
@@ -1386,7 +1377,7 @@ mod tests {
 
         #[test]
         fn add_remove_slashers() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             let env = mock_env();
             default_instantiate(deps.as_mut());
 
@@ -1472,7 +1463,7 @@ mod tests {
 
         #[test]
         fn slashing_nonexisting_member() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());
 
             // confirm address doesn't return true on slasher query
@@ -1491,7 +1482,7 @@ mod tests {
 
         #[test]
         fn slashing_bonded_tokens_works() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());
             let cfg = CONFIG.load(&deps.storage).unwrap();
             let slasher = add_slasher(deps.as_mut());
@@ -1511,7 +1502,7 @@ mod tests {
 
         #[test]
         fn slashing_claims_works() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());
             let cfg = CONFIG.load(&deps.storage).unwrap();
             let slasher = add_slasher(deps.as_mut());
@@ -1551,7 +1542,7 @@ mod tests {
 
         #[test]
         fn random_user_cannot_slash() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());
             let _slasher = add_slasher(deps.as_mut());
 
@@ -1570,7 +1561,7 @@ mod tests {
 
         #[test]
         fn admin_cannot_slash() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());
             let _slasher = add_slasher(deps.as_mut());
 
@@ -1589,7 +1580,7 @@ mod tests {
 
         #[test]
         fn removed_slasher_cannot_slash() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());
 
             // Add, then remove a slasher
@@ -1612,7 +1603,7 @@ mod tests {
 
     #[test]
     fn hooks_fire() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
@@ -1680,7 +1671,7 @@ mod tests {
 
     #[test]
     fn only_bond_valid_coins() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         // cannot bond with 0 coins
@@ -1707,7 +1698,7 @@ mod tests {
     #[test]
     fn ensure_bonding_edge_cases() {
         // use min_bond 0, tokens_per_points 500
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         do_instantiate(deps.as_mut(), Uint128::new(100), Uint128::zero(), 5, 0);
 
         // setting 50 tokens, gives us Some(0) points
@@ -1722,7 +1713,7 @@ mod tests {
 
     #[test]
     fn paginated_claim_query() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
 
         // create some data
@@ -1833,7 +1824,7 @@ mod tests {
 
         #[test]
         fn single_claim() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 2);
 
             bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -1850,7 +1841,7 @@ mod tests {
 
         #[test]
         fn multiple_users_claims() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 4);
 
             bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -1868,7 +1859,7 @@ mod tests {
 
         #[test]
         fn single_user_multiple_claims() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 3);
 
             bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -1886,7 +1877,7 @@ mod tests {
 
         #[test]
         fn only_expired_claims() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 3);
 
             bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -1911,7 +1902,7 @@ mod tests {
 
         #[test]
         fn claim_returned_once() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 5);
 
             bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -1947,7 +1938,7 @@ mod tests {
 
         #[test]
         fn up_to_limit_claims_returned() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 2);
 
             bond(deps.as_mut(), 12_000, 7_500, 4_000, 1);
@@ -2000,7 +1991,7 @@ mod tests {
 
         #[test]
         fn unbound_with_invalid_denom_fails() {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             do_instantiate(deps.as_mut(), 2);
 
             bond(deps.as_mut(), 5_000, 0, 0, 1);

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -17,7 +17,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw2 = "0.11.1"
+cw2 = "0.12.1"
 tg3 = { path = "../../packages/tg3", version = "0.6.2" }
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
@@ -31,6 +31,6 @@ thiserror = "1"
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta5"
-cw-multi-test = "0.11.1"
+cw-multi-test = "0.12.1"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2" }
 tg4 = { path = "../../packages/tg4", version = "0.6.2" }

--- a/contracts/tgrade-community-pool/src/contract.rs
+++ b/contracts/tgrade-community-pool/src/contract.rs
@@ -218,24 +218,14 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, Contra
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::marker::PhantomData;
 
-    use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
-    use cosmwasm_std::{from_slice, testing::mock_env, Addr, Decimal, OwnedDeps};
+    use cosmwasm_std::{from_slice, testing::mock_env, Addr, Decimal};
+    use tg_bindings_test::mock_deps_tgrade;
     use tg_voting_contract::state::VotingRules;
-
-    fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, TgradeQuery> {
-        OwnedDeps {
-            storage: MockStorage::default(),
-            api: MockApi::default(),
-            querier: MockQuerier::default(),
-            custom_query_type: PhantomData,
-        }
-    }
 
     #[test]
     fn query_group_contract() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         let rules = VotingRules {
             voting_period: 1,

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{coin, Addr, CosmosMsg, CustomQuery, StdResult};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use serde::de::DeserializeOwned;
 use tg4::{Member, Tg4ExecuteMsg};
-use tg_bindings::{TgradeMsg, TgradeQuery};
+use tg_bindings::TgradeMsg;
 use tg_bindings_test::TgradeApp;
 
 use tg_voting_contract::state::{RulesBuilder, VotingRules};

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -1,19 +1,17 @@
 use anyhow::{anyhow, Result as AnyResult};
 
-use cosmwasm_std::{coin, Addr, CosmosMsg, CustomQuery, StdResult};
+use cosmwasm_std::{coin, Addr, CosmosMsg, StdResult};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
-use serde::de::DeserializeOwned;
 use tg4::{Member, Tg4ExecuteMsg};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::TgradeApp;
 
 use tg_voting_contract::state::{RulesBuilder, VotingRules};
 
 use crate::msg::{ExecuteMsg, Proposal};
 
-fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+fn contract_validator_proposals() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
@@ -22,9 +20,8 @@ fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
     Box::new(contract)
 }
 
-fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -1,17 +1,19 @@
 use anyhow::{anyhow, Result as AnyResult};
 
-use cosmwasm_std::{coin, Addr, CosmosMsg, StdResult};
+use cosmwasm_std::{coin, Addr, CosmosMsg, CustomQuery, StdResult};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
+use serde::de::DeserializeOwned;
 use tg4::{Member, Tg4ExecuteMsg};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::TgradeApp;
 
 use tg_voting_contract::state::{RulesBuilder, VotingRules};
 
 use crate::msg::{ExecuteMsg, Proposal};
 
-fn contract_validator_proposals() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
@@ -20,8 +22,9 @@ fn contract_validator_proposals() -> Box<dyn Contract<TgradeMsg>> {
     Box::new(contract)
 }
 
-fn contract_engagement() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -24,7 +24,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta5"
-cw-storage-plus = "0.11.1"
+cw-storage-plus = "0.12.1"
 tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -17,7 +17,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw2 = "0.11.1"
+cw2 = "0.12.1"
 tg3 = { path = "../../packages/tg3", version = "0.6.2" }
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
@@ -30,8 +30,8 @@ thiserror = "1"
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta5"
-cw-multi-test = "0.11.1"
-cw-storage-plus = "0.11.1"
+cw-multi-test = "0.12.1"
+cw-storage-plus = "0.12.1"
 tg-bindings-test = { version = "0.6.2", path = "../../packages/bindings-test" }
 tg-utils = { version = "0.6.2", path = "../../packages/utils" }
 tg-voting-contract = { version = "0.6.2", path = "../../packages/voting-contract" }

--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_slice, to_binary, to_vec, Binary, ContractInfoResponse, ContractResult, Deps, DepsMut,
-    Empty, Env, MessageInfo, QueryRequest, StdResult, SystemResult, WasmMsg, WasmQuery,
+    from_slice, to_binary, to_vec, Binary, ContractInfoResponse, ContractResult, CustomQuery, Deps,
+    DepsMut, Empty, Env, MessageInfo, QueryRequest, StdResult, SystemResult, WasmMsg, WasmQuery,
 };
 
 use cw2::set_contract_version;
@@ -30,8 +30,8 @@ const CONTRACT_NAME: &str = "crates.io:tgrade_validator_voting_proposals";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn instantiate(
-    deps: DepsMut,
+pub fn instantiate<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     _env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -41,8 +41,8 @@ pub fn instantiate(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn execute(
-    deps: DepsMut,
+pub fn execute<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -72,17 +72,19 @@ pub fn execute(
                 .map_err(ContractError::from)
         }
         Vote { proposal_id, vote } => {
-            execute_vote::<ValidatorProposal>(deps, env, info, proposal_id, vote)
+            execute_vote::<ValidatorProposal, Q>(deps, env, info, proposal_id, vote)
                 .map_err(ContractError::from)
         }
         Execute { proposal_id } => execute_execute(deps, env, info, proposal_id),
-        Close { proposal_id } => execute_close::<ValidatorProposal>(deps, env, info, proposal_id)
-            .map_err(ContractError::from),
+        Close { proposal_id } => {
+            execute_close::<ValidatorProposal, Q>(deps, env, info, proposal_id)
+                .map_err(ContractError::from)
+        }
     }
 }
 
-fn confirm_admin_in_contract(
-    deps: Deps,
+fn confirm_admin_in_contract<Q: CustomQuery>(
+    deps: Deps<Q>,
     env: &Env,
     contract_addr: String,
 ) -> Result<(), ContractError> {
@@ -114,8 +116,8 @@ fn confirm_admin_in_contract(
     ))
 }
 
-pub fn execute_execute(
-    deps: DepsMut,
+pub fn execute_execute<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     proposal_id: u64,
@@ -203,18 +205,18 @@ fn align_limit(limit: Option<u32>) -> usize {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query<Q: CustomQuery>(deps: Deps<Q>, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     use QueryMsg::*;
 
     match msg {
         Rules {} => to_binary(&query_rules(deps)?),
-        Proposal { proposal_id } => to_binary(&query_proposal::<ValidatorProposal>(
+        Proposal { proposal_id } => to_binary(&query_proposal::<ValidatorProposal, Q>(
             deps,
             env,
             proposal_id,
         )?),
         Vote { proposal_id, voter } => to_binary(&query_vote(deps, proposal_id, voter)?),
-        ListProposals { start_after, limit } => to_binary(&list_proposals::<ValidatorProposal>(
+        ListProposals { start_after, limit } => to_binary(&list_proposals::<ValidatorProposal, Q>(
             deps,
             env,
             start_after,
@@ -223,7 +225,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         ReverseProposals {
             start_before,
             limit,
-        } => to_binary(&reverse_proposals::<ValidatorProposal>(
+        } => to_binary(&reverse_proposals::<ValidatorProposal, Q>(
             deps,
             env,
             start_before,
@@ -259,14 +261,18 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn sudo(deps: DepsMut, _env: Env, msg: TgradeSudoMsg) -> Result<Response, ContractError> {
+pub fn sudo<Q: CustomQuery>(
+    _deps: DepsMut<Q>,
+    _env: Env,
+    msg: TgradeSudoMsg,
+) -> Result<Response, ContractError> {
     match msg {
-        TgradeSudoMsg::PrivilegeChange(change) => Ok(privilege_change(deps, change)),
+        TgradeSudoMsg::PrivilegeChange(change) => Ok(privilege_change(change)),
         _ => Err(ContractError::UnsupportedSudoType {}),
     }
 }
 
-fn privilege_change(_deps: DepsMut, change: PrivilegeChangeMsg) -> Response {
+fn privilege_change(change: PrivilegeChangeMsg) -> Response {
     match change {
         PrivilegeChangeMsg::Promoted {} => {
             let msgs = request_privileges(&[

--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -295,33 +295,23 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, Contra
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{
         testing::{mock_env, mock_info},
-        Addr, CosmosMsg, Decimal, OwnedDeps, SubMsg,
+        Addr, CosmosMsg, Decimal, SubMsg,
     };
-    use std::marker::PhantomData;
     use tg_utils::Expiration;
     use tg_voting_contract::state::{proposals, Proposal, Votes, VotingRules};
 
     use super::*;
     use tg3::Status;
+    use tg_bindings_test::mock_deps_tgrade;
 
     #[derive(serde::Serialize)]
     struct DummyMigrateMsg {}
 
-    fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, TgradeQuery> {
-        OwnedDeps {
-            storage: MockStorage::default(),
-            api: MockApi::default(),
-            querier: MockQuerier::default(),
-            custom_query_type: PhantomData,
-        }
-    }
-
     #[test]
     fn register_migrate() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         proposals()
             .save(
@@ -370,7 +360,7 @@ mod tests {
 
     #[test]
     fn register_cancel_upgrade() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         proposals()
             .save(
@@ -416,7 +406,7 @@ mod tests {
 
     #[test]
     fn register_pin_codes() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         proposals()
             .save(
@@ -462,7 +452,7 @@ mod tests {
 
     #[test]
     fn register_unpin_codes() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         proposals()
             .save(
@@ -508,7 +498,7 @@ mod tests {
 
     #[test]
     fn update_consensus_block_params() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         proposals()
             .save(
@@ -559,7 +549,7 @@ mod tests {
 
     #[test]
     fn update_consensus_evidence_params() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         proposals()
             .save(
@@ -612,7 +602,7 @@ mod tests {
 
     #[test]
     fn query_group_contract() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let env = mock_env();
         let rules = VotingRules {
             voting_period: 1,

--- a/contracts/tgrade-validator-voting/src/multitest/hackatom.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/hackatom.rs
@@ -1,10 +1,12 @@
 //! Simplified contract which when executed releases the funds to beneficiary
 //! Copied almost 1:1 from https://github.com/CosmWasm/cw-plus/blob/main/packages/multi-test/src/test_helpers/contracts/hackatom.rs
 
-use cosmwasm_std::{to_binary, BankMsg, Binary, Deps, DepsMut, Env, MessageInfo, StdError};
+use cosmwasm_std::{
+    to_binary, BankMsg, Binary, CustomQuery, Deps, DepsMut, Env, MessageInfo, StdError,
+};
 use cw_storage_plus::Item;
 use serde::{Deserialize, Serialize};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 
 use cw_multi_test::{Contract, ContractWrapper};
 
@@ -33,8 +35,8 @@ pub enum QueryMsg {
 
 const HACKATOM: Item<InstantiateMsg> = Item::new("hackatom");
 
-fn instantiate(
-    deps: DepsMut,
+fn instantiate<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     _env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -43,8 +45,8 @@ fn instantiate(
     Ok(Response::default())
 }
 
-fn execute(
-    deps: DepsMut,
+fn execute<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     _info: MessageInfo,
     _msg: ExecuteMsg,
@@ -60,7 +62,7 @@ fn execute(
     Ok(resp)
 }
 
-fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, StdError> {
+fn query<Q: CustomQuery>(deps: Deps<Q>, _env: Env, msg: QueryMsg) -> Result<Binary, StdError> {
     match msg {
         QueryMsg::Beneficiary {} => {
             let res = HACKATOM.load(deps.storage)?;
@@ -69,7 +71,11 @@ fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, StdError> {
     }
 }
 
-fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, StdError> {
+fn migrate<Q: CustomQuery>(
+    deps: DepsMut<Q>,
+    _env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, StdError> {
     HACKATOM.update::<_, StdError>(deps.storage, |mut state| {
         state.beneficiary = msg.new_guy;
         Ok(state)
@@ -78,7 +84,9 @@ fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, StdErr
     Ok(resp)
 }
 
-pub fn contract() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(execute, instantiate, query).with_migrate(migrate);
+pub fn contract() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract =
+        ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(execute, instantiate, query)
+            .with_migrate(migrate);
     Box::new(contract)
 }

--- a/contracts/tgrade-validator-voting/src/multitest/hackatom.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/hackatom.rs
@@ -85,8 +85,6 @@ fn migrate<Q: CustomQuery>(
 }
 
 pub fn contract() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
-    let contract =
-        ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(execute, instantiate, query)
-            .with_migrate(migrate);
+    let contract = ContractWrapper::new(execute, instantiate, query).with_migrate(migrate);
     Box::new(contract)
 }

--- a/contracts/tgrade-validator-voting/src/multitest/suite.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/suite.rs
@@ -1,11 +1,10 @@
 use anyhow::Result as AnyResult;
 
-use cosmwasm_std::{to_binary, Addr, ContractInfoResponse, CustomQuery, Decimal};
+use cosmwasm_std::{to_binary, Addr, ContractInfoResponse, Decimal};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
-use serde::de::DeserializeOwned;
 use tg3::Status;
 use tg4::{Member, Tg4ExecuteMsg};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::{TgradeApp, UpgradePlan};
 
 use crate::msg::ValidatorProposal;
@@ -17,9 +16,8 @@ pub fn get_proposal_id(response: &AppResponse) -> Result<u64, std::num::ParseInt
     response.custom_attrs(1)[2].value.parse()
 }
 
-fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+fn contract_validator_proposals() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
@@ -29,9 +27,8 @@ fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
     Box::new(contract)
 }
 
-fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,

--- a/contracts/tgrade-validator-voting/src/multitest/suite.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/suite.rs
@@ -5,7 +5,7 @@ use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
 use serde::de::DeserializeOwned;
 use tg3::Status;
 use tg4::{Member, Tg4ExecuteMsg};
-use tg_bindings::{TgradeMsg, TgradeQuery};
+use tg_bindings::TgradeMsg;
 use tg_bindings_test::{TgradeApp, UpgradePlan};
 
 use crate::msg::ValidatorProposal;
@@ -29,8 +29,8 @@ fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
     Box::new(contract)
 }
 
-fn contract_valset<Q: 'static + CustomQuery + DeserializeOwned>() -> Box<dyn Contract<TgradeMsg, Q>>
-{
+fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
     let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,

--- a/contracts/tgrade-validator-voting/src/multitest/suite.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/suite.rs
@@ -1,10 +1,11 @@
 use anyhow::Result as AnyResult;
 
-use cosmwasm_std::{to_binary, Addr, ContractInfoResponse, Decimal};
+use cosmwasm_std::{to_binary, Addr, ContractInfoResponse, CustomQuery, Decimal};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, Executor};
+use serde::de::DeserializeOwned;
 use tg3::Status;
 use tg4::{Member, Tg4ExecuteMsg};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::{TgradeApp, UpgradePlan};
 
 use crate::msg::ValidatorProposal;
@@ -16,8 +17,9 @@ pub fn get_proposal_id(response: &AppResponse) -> Result<u64, std::num::ParseInt
     response.custom_attrs(1)[2].value.parse()
 }
 
-fn contract_validator_proposals() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+fn contract_validator_proposals<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
@@ -27,8 +29,9 @@ fn contract_validator_proposals() -> Box<dyn Contract<TgradeMsg>> {
     Box::new(contract)
 }
 
-fn contract_engagement() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+fn contract_valset<Q: 'static + CustomQuery + DeserializeOwned>() -> Box<dyn Contract<TgradeMsg, Q>>
+{
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -27,17 +27,17 @@ library = []
 integration = ["bech32", "cosmwasm-vm"]
 
 [dependencies]
-cw-utils = { version = "0.12.1" }
+cosmwasm-std = { version = "1.0.0-beta5" }
 cw2 = { version = "0.12.1" }
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
-tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.2", path = "../../packages/utils" }
+cw-utils = { version = "0.12.1" }
 cw-controllers = { version = "0.12.1" }
 cw-storage-plus = { version = "0.12.1" }
-cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2" }
+tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.2", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -27,13 +27,13 @@ library = []
 integration = ["bech32", "cosmwasm-vm"]
 
 [dependencies]
-cw-utils = { version = "0.11.1" }
-cw2 = { version = "0.11.1" }
+cw-utils = { version = "0.12.1" }
+cw2 = { version = "0.12.1" }
 tg4 = { path = "../../packages/tg4", version = "0.6.2" }
 tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
 tg-utils = { version = "0.6.2", path = "../../packages/utils" }
-cw-controllers = { version = "0.11.1" }
-cw-storage-plus = { version = "0.11.1" }
+cw-controllers = { version = "0.12.1" }
+cw-storage-plus = { version = "0.12.1" }
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -45,7 +45,7 @@ cosmwasm-vm = { version = "1.0.0-beta5", optional = true, default-features = fal
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta5" }
-cw-multi-test = "0.11.1"
+cw-multi-test = "0.12.1"
 tg4-engagement = { path = "../tg4-engagement", version = "0.6.2" }
 tg4-stake = { path = "../tg4-stake", version = "0.6.2" }
 # we enable multitest feature only for tests

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -5,8 +5,8 @@ use std::convert::TryInto;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, BlockInfo, Decimal, Deps, DepsMut, Env, MessageInfo, Order, Reply,
-    StdError, StdResult, Timestamp, WasmMsg,
+    to_binary, Addr, Binary, BlockInfo, CustomQuery, Decimal, Deps, DepsMut, Env, MessageInfo,
+    Order, Reply, StdError, StdResult, Timestamp, WasmMsg,
 };
 
 use cw2::set_contract_version;
@@ -45,8 +45,8 @@ pub type Response = cosmwasm_std::Response<TgradeMsg>;
 pub type SubMsg = cosmwasm_std::SubMsg<TgradeMsg>;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn instantiate(
-    deps: DepsMut,
+pub fn instantiate<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -139,8 +139,8 @@ pub fn instantiate(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn execute(
-    deps: DepsMut,
+pub fn execute<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -174,8 +174,8 @@ pub fn execute(
     }
 }
 
-fn execute_update_config(
-    deps: DepsMut,
+fn execute_update_config<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     info: MessageInfo,
     min_points: Option<u64>,
     max_validators: Option<u32>,
@@ -199,8 +199,8 @@ fn execute_update_config(
     Ok(res)
 }
 
-fn execute_register_validator_key(
-    deps: DepsMut,
+fn execute_register_validator_key<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     _env: Env,
     info: MessageInfo,
     pubkey: Pubkey,
@@ -231,8 +231,8 @@ fn execute_register_validator_key(
     Ok(res)
 }
 
-fn execute_update_metadata(
-    deps: DepsMut,
+fn execute_update_metadata<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     _env: Env,
     info: MessageInfo,
     metadata: ValidatorMetadata,
@@ -257,8 +257,8 @@ fn execute_update_metadata(
     Ok(res)
 }
 
-fn execute_jail(
-    deps: DepsMut,
+fn execute_jail<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     operator: String,
@@ -287,8 +287,8 @@ fn execute_jail(
     Ok(res)
 }
 
-fn execute_unjail(
-    deps: DepsMut,
+fn execute_unjail<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     operator: Option<String>,
@@ -325,8 +325,8 @@ fn execute_unjail(
     Ok(res)
 }
 
-fn store_slashing_event(
-    deps: DepsMut,
+fn store_slashing_event<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: &Env,
     addr: Addr,
     portion: Decimal,
@@ -342,8 +342,8 @@ fn store_slashing_event(
     Ok(())
 }
 
-fn execute_slash(
-    mut deps: DepsMut,
+fn execute_slash<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     env: Env,
     info: MessageInfo,
     operator: String,
@@ -375,8 +375,8 @@ fn execute_slash(
 }
 
 #[cfg(debug_assertions)]
-fn execute_simulate_validators(
-    deps: DepsMut,
+fn execute_simulate_validators<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     _info: MessageInfo,
     validators: Vec<ValidatorInfo>,
 ) -> Result<Response, ContractError> {
@@ -398,7 +398,11 @@ fn execute_simulate_validators(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+pub fn query<Q: CustomQuery>(
+    deps: Deps<Q>,
+    env: Env,
+    msg: QueryMsg,
+) -> Result<Binary, ContractError> {
     use QueryMsg::*;
     match msg {
         Configuration {} => Ok(to_binary(&CONFIG.load(deps.storage)?)?),
@@ -429,7 +433,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
     }
 }
 
-fn query_epoch(deps: Deps, env: Env) -> Result<EpochResponse, ContractError> {
+fn query_epoch<Q: CustomQuery>(deps: Deps<Q>, env: Env) -> Result<EpochResponse, ContractError> {
     let epoch = EPOCH.load(deps.storage)?;
     let mut next_update_time =
         Timestamp::from_seconds((epoch.current_epoch + 1) * epoch.epoch_length);
@@ -447,8 +451,8 @@ fn query_epoch(deps: Deps, env: Env) -> Result<EpochResponse, ContractError> {
     Ok(resp)
 }
 
-fn query_validator_key(
-    deps: Deps,
+fn query_validator_key<Q: CustomQuery>(
+    deps: Deps<Q>,
     env: Env,
     operator: String,
 ) -> Result<ValidatorResponse, ContractError> {
@@ -470,8 +474,8 @@ fn query_validator_key(
 const MAX_LIMIT: u32 = 100;
 const DEFAULT_LIMIT: u32 = 30;
 
-fn list_validator_keys(
-    deps: Deps,
+fn list_validator_keys<Q: CustomQuery>(
+    deps: Deps<Q>,
     env: Env,
     start_after: Option<String>,
     limit: Option<u32>,
@@ -506,8 +510,8 @@ fn list_validator_keys(
     })
 }
 
-fn list_active_validators(
-    deps: Deps,
+fn list_active_validators<Q: CustomQuery>(
+    deps: Deps<Q>,
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> Result<ListActiveValidatorsResponse, ContractError> {
@@ -532,8 +536,8 @@ fn list_active_validators(
     })
 }
 
-fn list_jailed_validators(
-    deps: Deps,
+fn list_jailed_validators<Q: CustomQuery>(
+    deps: Deps<Q>,
     env: Env,
     start_after: Option<String>,
     limit: Option<u32>,
@@ -572,16 +576,16 @@ fn list_jailed_validators(
     Ok(ListValidatorResponse { validators })
 }
 
-fn simulate_active_validators(
-    deps: Deps,
+fn simulate_active_validators<Q: CustomQuery>(
+    deps: Deps<Q>,
     env: Env,
 ) -> Result<ListActiveValidatorsResponse, ContractError> {
     let (validators, _) = calculate_validators(deps, &env)?;
     Ok(ListActiveValidatorsResponse { validators })
 }
 
-fn list_validator_slashing(
-    deps: Deps,
+fn list_validator_slashing<Q: CustomQuery>(
+    deps: Deps<Q>,
     _env: Env,
     operator: String,
 ) -> Result<ListValidatorSlashingResponse, ContractError> {
@@ -608,7 +612,11 @@ fn list_validator_slashing(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn sudo(deps: DepsMut, env: Env, msg: TgradeSudoMsg) -> Result<Response, ContractError> {
+pub fn sudo<Q: CustomQuery>(
+    deps: DepsMut<Q>,
+    env: Env,
+    msg: TgradeSudoMsg,
+) -> Result<Response, ContractError> {
     match msg {
         TgradeSudoMsg::PrivilegeChange(change) => Ok(privilege_change(deps, change)),
         TgradeSudoMsg::EndWithValidatorUpdate {} => end_block(deps, env),
@@ -617,7 +625,7 @@ pub fn sudo(deps: DepsMut, env: Env, msg: TgradeSudoMsg) -> Result<Response, Con
     }
 }
 
-fn privilege_change(_deps: DepsMut, change: PrivilegeChangeMsg) -> Response {
+fn privilege_change<Q: CustomQuery>(_deps: DepsMut<Q>, change: PrivilegeChangeMsg) -> Response {
     match change {
         PrivilegeChangeMsg::Promoted {} => {
             let msgs = request_privileges(&[
@@ -642,7 +650,7 @@ fn is_genesis_block(block: &BlockInfo) -> bool {
     block.height < 2
 }
 
-fn end_block(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
+fn end_block<Q: CustomQuery>(deps: DepsMut<Q>, env: Env) -> Result<Response, ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
 
     // check if needed and quit early if we didn't hit epoch boundary
@@ -736,8 +744,8 @@ const QUERY_LIMIT: Option<u32> = Some(30);
 
 /// Selects validators to be used for incoming epoch. Returns vector of validators info paired
 /// with vector of addresses to be un-jailed (always empty if auto un-jailing is disabled).
-fn calculate_validators(
-    deps: Deps,
+fn calculate_validators<Q: CustomQuery>(
+    deps: Deps<Q>,
     env: &Env,
 ) -> Result<(Vec<ValidatorInfo>, Vec<Addr>), ContractError> {
     let cfg = CONFIG.load(deps.storage)?;
@@ -873,7 +881,11 @@ fn calculate_diff(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate<Q: CustomQuery>(
+    deps: DepsMut<Q>,
+    _env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, ContractError> {
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     CONFIG.update::<_, StdError>(deps.storage, |mut cfg| {
@@ -899,8 +911,8 @@ mod evidence {
     /// suspect, this function computes sha256 hashes for all existing validator and
     /// compares result with suspect. It is acceptable approach, since it shouldn't
     /// happen too often.
-    pub fn find_matching_validator(
-        deps: Deps,
+    pub fn find_matching_validator<Q: CustomQuery>(
+        deps: Deps<Q>,
         suspect: &Validator,
         evidence_height: u64,
     ) -> Result<Option<Addr>, cosmwasm_std::StdError> {
@@ -941,8 +953,8 @@ mod evidence {
 
 /// If some validators are caught on malicious behavior (for example double signing),
 /// they are reported and punished on begin of next block.
-fn begin_block(
-    mut deps: DepsMut,
+fn begin_block<Q: CustomQuery>(
+    mut deps: DepsMut<Q>,
     env: Env,
     evidences: Vec<Evidence>,
 ) -> Result<Response, ContractError> {
@@ -991,15 +1003,19 @@ fn begin_block(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {
+pub fn reply<Q: CustomQuery>(
+    deps: DepsMut<Q>,
+    env: Env,
+    msg: Reply,
+) -> Result<Response, ContractError> {
     match msg.id {
         REWARDS_INIT_REPLY_ID => rewards_instantiate_reply(deps, env, msg),
         _ => Err(ContractError::UnrecognisedReply(msg.id)),
     }
 }
 
-pub fn rewards_instantiate_reply(
-    deps: DepsMut,
+pub fn rewards_instantiate_reply<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     _env: Env,
     msg: Reply,
 ) -> Result<Response, ContractError> {

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -17,7 +17,7 @@ use cw_utils::{maybe_addr, parse_reply_instantiate_data};
 use tg4::{Member, Tg4Contract};
 use tg_bindings::{
     request_privileges, Ed25519Pubkey, Evidence, EvidenceType, Privilege, PrivilegeChangeMsg,
-    Pubkey, TgradeMsg, TgradeSudoMsg, ValidatorDiff, ValidatorUpdate,
+    Pubkey, TgradeMsg, TgradeQuery, TgradeSudoMsg, ValidatorDiff, ValidatorUpdate,
 };
 use tg_utils::{ensure_from_older_version, JailingDuration, SlashMsg, ADMIN};
 
@@ -45,8 +45,8 @@ pub type Response = cosmwasm_std::Response<TgradeMsg>;
 pub type SubMsg = cosmwasm_std::SubMsg<TgradeMsg>;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn instantiate<Q: CustomQuery>(
-    deps: DepsMut<Q>,
+pub fn instantiate(
+    deps: DepsMut<TgradeQuery>,
     env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -139,8 +139,8 @@ pub fn instantiate<Q: CustomQuery>(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn execute<Q: CustomQuery>(
-    deps: DepsMut<Q>,
+pub fn execute(
+    deps: DepsMut<TgradeQuery>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -398,11 +398,7 @@ fn execute_simulate_validators<Q: CustomQuery>(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query<Q: CustomQuery>(
-    deps: Deps<Q>,
-    env: Env,
-    msg: QueryMsg,
-) -> Result<Binary, ContractError> {
+pub fn query(deps: Deps<TgradeQuery>, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     use QueryMsg::*;
     match msg {
         Configuration {} => Ok(to_binary(&CONFIG.load(deps.storage)?)?),
@@ -612,8 +608,8 @@ fn list_validator_slashing<Q: CustomQuery>(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn sudo<Q: CustomQuery>(
-    deps: DepsMut<Q>,
+pub fn sudo(
+    deps: DepsMut<TgradeQuery>,
     env: Env,
     msg: TgradeSudoMsg,
 ) -> Result<Response, ContractError> {
@@ -881,8 +877,8 @@ fn calculate_diff(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate<Q: CustomQuery>(
-    deps: DepsMut<Q>,
+pub fn migrate(
+    deps: DepsMut<TgradeQuery>,
     _env: Env,
     msg: MigrateMsg,
 ) -> Result<Response, ContractError> {
@@ -1003,11 +999,7 @@ fn begin_block<Q: CustomQuery>(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply<Q: CustomQuery>(
-    deps: DepsMut<Q>,
-    env: Env,
-    msg: Reply,
-) -> Result<Response, ContractError> {
+pub fn reply(deps: DepsMut<TgradeQuery>, env: Env, msg: Reply) -> Result<Response, ContractError> {
     match msg.id {
         REWARDS_INIT_REPLY_ID => rewards_instantiate_reply(deps, env, msg),
         _ => Err(ContractError::UnrecognisedReply(msg.id)),

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -479,7 +479,7 @@ fn list_validator_keys(
     let cfg = CONFIG.load(deps.storage)?;
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start_after = maybe_addr(deps.api, start_after)?;
-    let start = start_after.map(|addr| Bound::exclusive(addr.as_str()));
+    let start = start_after.as_ref().map(Bound::exclusive);
 
     let operators: StdResult<Vec<_>> = operators()
         .range(deps.storage, start, None, Order::Ascending)
@@ -541,7 +541,7 @@ fn list_jailed_validators(
     let cfg = CONFIG.load(deps.storage)?;
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     let start_after = maybe_addr(deps.api, start_after)?;
-    let start = start_after.map(|addr| Bound::exclusive(addr.as_str()));
+    let start = start_after.as_ref().map(Bound::exclusive);
 
     let validators = JAIL
         .range(deps.storage, start, None, Order::Ascending)

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -368,7 +368,7 @@ fn update_metadata_invalid_metadata() {
 mod instantiate {
     use cosmwasm_std::{coin, Addr, Decimal, Uint128};
     use cw_multi_test::{AppBuilder, BasicApp, Executor};
-    use tg_bindings::TgradeMsg;
+    use tg_bindings::{TgradeMsg, TgradeQuery};
 
     use crate::error::ContractError;
     use crate::msg::{
@@ -380,7 +380,8 @@ mod instantiate {
 
     #[test]
     fn instantiate_invalid_metadata() {
-        let mut app: BasicApp<TgradeMsg> = AppBuilder::new_custom().build(|_, _, _| ());
+        let mut app: BasicApp<TgradeMsg, TgradeQuery> =
+            AppBuilder::new_custom().build(|_, _, _| ());
 
         let stake_id = app.store_code(contract_stake());
         let admin = "steakhouse owner".to_owned();

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -10,7 +10,7 @@ use cw_multi_test::{next_block, AppResponse, Contract, ContractWrapper, CosmosRo
 use derivative::Derivative;
 use serde::de::DeserializeOwned;
 use tg4::{AdminResponse, Member};
-use tg_bindings::{Evidence, Pubkey, TgradeMsg,ValidatorDiff};
+use tg_bindings::{Evidence, Pubkey, TgradeMsg, ValidatorDiff};
 use tg_bindings_test::TgradeApp;
 use tg_utils::{Duration, JailingDuration};
 

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -4,21 +4,19 @@ use crate::test_helpers::{mock_metadata, mock_pubkey};
 use crate::{msg::*, state::ValidatorInfo};
 use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::{
-    coin, Addr, BlockInfo, Coin, CosmosMsg, CustomQuery, Decimal, StdResult, Timestamp, Uint128,
+    coin, Addr, BlockInfo, Coin, CosmosMsg, Decimal, StdResult, Timestamp, Uint128,
 };
 use cw_multi_test::{next_block, AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use derivative::Derivative;
-use serde::de::DeserializeOwned;
 use tg4::{AdminResponse, Member};
-use tg_bindings::{Evidence, Pubkey, TgradeMsg, ValidatorDiff};
+use tg_bindings::{Evidence, Pubkey, TgradeMsg, TgradeQuery, ValidatorDiff};
 use tg_bindings_test::TgradeApp;
 use tg_utils::{Duration, JailingDuration};
 
 use crate::msg::OperatorInitInfo;
 
-pub fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+pub fn contract_engagement() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,
@@ -26,9 +24,8 @@ pub fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
     Box::new(contract)
 }
 
-pub fn contract_stake<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+pub fn contract_stake() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         tg4_stake::contract::execute,
         tg4_stake::contract::instantiate,
         tg4_stake::contract::query,
@@ -36,9 +33,8 @@ pub fn contract_stake<Q: 'static + CustomQuery + DeserializeOwned>(
     Box::new(contract)
 }
 
-pub fn contract_valset<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+pub fn contract_valset() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -10,7 +10,7 @@ use cw_multi_test::{next_block, AppResponse, Contract, ContractWrapper, CosmosRo
 use derivative::Derivative;
 use serde::de::DeserializeOwned;
 use tg4::{AdminResponse, Member};
-use tg_bindings::{Evidence, Pubkey, TgradeMsg, TgradeQuery, ValidatorDiff};
+use tg_bindings::{Evidence, Pubkey, TgradeMsg,ValidatorDiff};
 use tg_bindings_test::TgradeApp;
 use tg_utils::{Duration, JailingDuration};
 

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -4,19 +4,21 @@ use crate::test_helpers::{mock_metadata, mock_pubkey};
 use crate::{msg::*, state::ValidatorInfo};
 use anyhow::{bail, Result as AnyResult};
 use cosmwasm_std::{
-    coin, Addr, BlockInfo, Coin, CosmosMsg, Decimal, StdResult, Timestamp, Uint128,
+    coin, Addr, BlockInfo, Coin, CosmosMsg, CustomQuery, Decimal, StdResult, Timestamp, Uint128,
 };
 use cw_multi_test::{next_block, AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use derivative::Derivative;
+use serde::de::DeserializeOwned;
 use tg4::{AdminResponse, Member};
-use tg_bindings::{Evidence, Pubkey, TgradeMsg, ValidatorDiff};
+use tg_bindings::{Evidence, Pubkey, TgradeMsg, TgradeQuery, ValidatorDiff};
 use tg_bindings_test::TgradeApp;
 use tg_utils::{Duration, JailingDuration};
 
 use crate::msg::OperatorInitInfo;
 
-pub fn contract_engagement() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+pub fn contract_engagement<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,
@@ -24,8 +26,9 @@ pub fn contract_engagement() -> Box<dyn Contract<TgradeMsg>> {
     Box::new(contract)
 }
 
-pub fn contract_stake() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+pub fn contract_stake<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         tg4_stake::contract::execute,
         tg4_stake::contract::instantiate,
         tg4_stake::contract::query,
@@ -33,8 +36,9 @@ pub fn contract_stake() -> Box<dyn Contract<TgradeMsg>> {
     Box::new(contract)
 }
 
-pub fn contract_valset() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+pub fn contract_valset<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tgrade-valset/src/rewards.rs
+++ b/contracts/tgrade-valset/src/rewards.rs
@@ -1,12 +1,14 @@
 use crate::msg::{DistributionMsg, RewardsDistribution};
 use crate::state::Config;
-use cosmwasm_std::{coins, to_binary, Coin, DepsMut, Env, StdResult, SubMsg, Uint128, WasmMsg};
+use cosmwasm_std::{
+    coins, to_binary, Addr, Coin, CustomQuery, DepsMut, Env, StdResult, SubMsg, Uint128, WasmMsg,
+};
 use tg_bindings::TgradeMsg;
 
 /// Ensure you pass in non-empty pay-validators, it will panic if total validator points is 0
 /// This handles all deps and calls into pure functions
-pub fn pay_block_rewards(
-    deps: DepsMut,
+pub fn pay_block_rewards<Q: CustomQuery>(
+    deps: DepsMut<Q>,
     env: Env,
     pay_epochs: u64,
     config: &Config,

--- a/contracts/tgrade-valset/src/rewards.rs
+++ b/contracts/tgrade-valset/src/rewards.rs
@@ -1,7 +1,7 @@
 use crate::msg::{DistributionMsg, RewardsDistribution};
 use crate::state::Config;
 use cosmwasm_std::{
-    coins, to_binary, Addr, Coin, CustomQuery, DepsMut, Env, StdResult, SubMsg, Uint128, WasmMsg,
+    coins, to_binary, Coin, CustomQuery, DepsMut, Env, StdResult, SubMsg, Uint128, WasmMsg,
 };
 use tg_bindings::TgradeMsg;
 

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -17,9 +17,9 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta5"
-cw-utils = "0.11.1"
-cw2 = "0.11.1"
-cw-storage-plus = "0.11.1"
+cw-utils = "0.12.1"
+cw2 = "0.12.1"
+cw-storage-plus = "0.12.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
@@ -31,5 +31,5 @@ anyhow = "1"
 assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta5"
-cw-multi-test = "0.11.1"
+cw-multi-test = "0.12.1"
 tg-bindings-test = { version = "0.6.2", path = "../../packages/bindings-test" }

--- a/contracts/tgrade-vesting-account/src/contract.rs
+++ b/contracts/tgrade-vesting-account/src/contract.rs
@@ -402,12 +402,11 @@ fn can_execute<Q: CustomQuery>(deps: Deps<Q>, sender: String) -> StdResult<CanEx
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::marker::PhantomData;
-
     use assert_matches::assert_matches;
 
     use cosmwasm_std::testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage};
     use cosmwasm_std::{from_binary, Coin, MessageInfo, OwnedDeps, Timestamp};
+    use tg_bindings_test::mock_deps_tgrade;
     use tg_utils::Expiration;
 
     const OWNER: &str = "owner";
@@ -419,15 +418,6 @@ mod tests {
     const DEFAULT_RELEASE: u64 = 1571797419 + 100;
 
     const VESTING_DENOM: &str = "vesting";
-
-    fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, TgradeQuery> {
-        OwnedDeps {
-            storage: MockStorage::default(),
-            api: MockApi::default(),
-            querier: MockQuerier::default(),
-            custom_query_type: PhantomData,
-        }
-    }
 
     struct SuiteBuilder {
         recipient: Addr,
@@ -461,7 +451,7 @@ mod tests {
         }
 
         fn build(self) -> Suite {
-            let mut deps = mock_dependencies();
+            let mut deps = mock_deps_tgrade();
             let owner = mock_info(self.recipient.as_str(), &self.coins);
 
             let instantiate_message = InstantiateMsg {
@@ -764,7 +754,7 @@ mod tests {
 
     #[test]
     fn instantiate_without_tokens() {
-        let mut deps = mock_dependencies();
+        let mut deps = mock_deps_tgrade();
         let owner = mock_info(OWNER, &[]);
 
         let instantiate_message = InstantiateMsg {

--- a/contracts/tgrade-vesting-account/src/multitest/suite.rs
+++ b/contracts/tgrade-vesting-account/src/multitest/suite.rs
@@ -1,18 +1,16 @@
 use crate::{error::ContractError, msg::*, state::*};
 
-use cosmwasm_std::{coin, Addr, CosmosMsg, CustomQuery, Timestamp, Uint128};
+use cosmwasm_std::{coin, Addr, CosmosMsg, Timestamp, Uint128};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 use tg_bindings_test::TgradeApp;
 use tg_utils::Expiration;
 
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
-use serde::de::DeserializeOwned;
 
-pub fn contract_vesting<Q: 'static + CustomQuery + DeserializeOwned>(
-) -> Box<dyn Contract<TgradeMsg, Q>> {
-    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
+pub fn contract_vesting() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,

--- a/contracts/tgrade-vesting-account/src/multitest/suite.rs
+++ b/contracts/tgrade-vesting-account/src/multitest/suite.rs
@@ -1,6 +1,6 @@
 use crate::{error::ContractError, msg::*, state::*};
 
-use cosmwasm_std::{coin, Addr, CosmosMsg, Timestamp, Uint128};
+use cosmwasm_std::{coin, Addr, CosmosMsg, CustomQuery, Timestamp, Uint128};
 use cw_multi_test::{AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use tg_bindings::TgradeMsg;
 use tg_bindings_test::TgradeApp;
@@ -8,9 +8,11 @@ use tg_utils::Expiration;
 
 use anyhow::Result as AnyResult;
 use derivative::Derivative;
+use serde::de::DeserializeOwned;
 
-pub fn vesting_contract() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+pub fn contract_vesting<Q: 'static + CustomQuery + DeserializeOwned>(
+) -> Box<dyn Contract<TgradeMsg, Q>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, Q>::new(
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
@@ -108,7 +110,7 @@ impl SuiteBuilder {
             })
             .unwrap();
 
-        let contract_id = self.app.store_code(vesting_contract());
+        let contract_id = self.app.store_code(contract_vesting());
         let recipient = Addr::unchecked(self.recipient);
         let operator = Addr::unchecked(self.operator);
         let oversight = Addr::unchecked(self.oversight);

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -13,7 +13,7 @@ tg-bindings = { version = "0.6.2", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-cw-multi-test = { version = "0.11.1" }
-cw-storage-plus = { version = "0.11.1" }
+cw-multi-test = { version = "0.12.1" }
+cw-storage-plus = { version = "1.12.1" }
 anyhow = { version = "1" }
 thiserror = { version = "1.0.21" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -14,6 +14,6 @@ cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 cw-multi-test = { version = "0.12.1" }
-cw-storage-plus = { version = "1.12.1" }
+cw-storage-plus = { version = "0.12.1" }
 anyhow = { version = "1" }
 thiserror = { version = "1.0.21" }

--- a/packages/bindings-test/src/lib.rs
+++ b/packages/bindings-test/src/lib.rs
@@ -1,5 +1,6 @@
 mod multitest;
 
 pub use multitest::{
-    Privileges, TgradeApp, TgradeAppWrapped, TgradeError, TgradeModule, UpgradePlan, BLOCK_TIME,
+    mock_deps_tgrade, Privileges, TgradeApp, TgradeAppWrapped, TgradeDeps, TgradeError,
+    TgradeModule, UpgradePlan, BLOCK_TIME,
 };

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -7,7 +7,10 @@ use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 use thiserror::Error;
 
-use cosmwasm_std::testing::{MockApi, MockStorage};
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::OwnedDeps;
+use std::marker::PhantomData;
+
 use cosmwasm_std::{
     from_slice, to_binary, Addr, Api, Binary, BlockInfo, Coin, CustomQuery, Empty, Order, Querier,
     QuerierResult, StdError, StdResult, Storage, Timestamp,
@@ -42,6 +45,17 @@ const ADMIN_PRIVILEGES: &[Privilege] = &[
     Privilege::TokenMinter,
     Privilege::ConsensusParamChanger,
 ];
+
+pub type TgradeDeps = OwnedDeps<MockStorage, MockApi, MockQuerier, TgradeQuery>;
+
+pub fn mock_deps_tgrade() -> TgradeDeps {
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: MockQuerier::default(),
+        custom_query_type: PhantomData,
+    }
+}
 
 impl TgradeModule {
     /// Intended for init_modules to set someone who can grant privileges or call arbitrary

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -12,10 +12,10 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta5"
-cw-utils = "0.11.1"
-cw-controllers = "0.11.1"
-cw-storage-plus = "0.11.1"
-cw2 = "0.11.1"
+cw-utils = "0.12.1"
+cw-controllers = "0.12.1"
+cw-storage-plus = "0.12.1"
+cw2 = "0.12.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg4 = { path = "../tg4", version = "0.6.2" }

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -11,9 +11,9 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cw-utils = "0.11.1"
+cw-utils = "0.12.1"
 tg3 = { path = "../../packages/tg3", version = "0.6.2" }
-cw-storage-plus = "0.11.1"
+cw-storage-plus = "0.12.1"
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
@@ -25,7 +25,7 @@ thiserror = { version = "1" }
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta5"
-cw-multi-test = "0.11.1"
+cw-multi-test = "0.12.1"
 derivative = "2"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2" }
 tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.2", features = ["library"] }

--- a/packages/voting-contract/src/lib.rs
+++ b/packages/voting-contract/src/lib.rs
@@ -302,7 +302,7 @@ pub fn list_proposals<P>(
 where
     P: Serialize + DeserializeOwned,
 {
-    let start = start_after.map(Bound::exclusive_int);
+    let start = start_after.map(Bound::exclusive);
     let props: StdResult<Vec<_>> = proposals()
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -317,7 +317,7 @@ pub fn list_text_proposals(
     start_after: Option<u64>,
     limit: usize,
 ) -> StdResult<TextProposalListResponse> {
-    let start = start_after.map(Bound::exclusive_int);
+    let start = start_after.map(Bound::exclusive);
     let props: StdResult<Vec<_>> = TEXT_PROPOSALS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -336,7 +336,7 @@ pub fn reverse_proposals<P>(
 where
     P: Serialize + DeserializeOwned,
 {
-    let end = start_before.map(Bound::exclusive_int);
+    let end = start_before.map(Bound::exclusive);
     let props: StdResult<Vec<_>> = proposals()
         .range(deps.storage, None, end, Order::Descending)
         .take(limit)
@@ -365,7 +365,7 @@ pub fn list_votes(
     limit: usize,
 ) -> StdResult<VoteListResponse> {
     let addr = maybe_addr(deps.api, start_after)?;
-    let start = addr.map(|addr| Bound::exclusive(addr.as_ref()));
+    let start = addr.as_ref().map(Bound::exclusive);
 
     let votes: StdResult<Vec<_>> = BALLOTS
         .prefix(proposal_id)
@@ -391,7 +391,7 @@ pub fn list_votes_by_voter(
     start_after: Option<u64>,
     limit: usize,
 ) -> StdResult<VoteListResponse> {
-    let start = start_after.map(Bound::exclusive_int);
+    let start = start_after.map(Bound::exclusive);
     let voter_addr = deps.api.addr_validate(&voter)?;
 
     let votes: StdResult<Vec<_>> = BALLOTS_BY_VOTER

--- a/packages/voting-contract/src/multitest/contracts.rs
+++ b/packages/voting-contract/src/multitest/contracts.rs
@@ -4,12 +4,12 @@ use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo};
 use cw_multi_test::{Contract, ContractWrapper};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tg_bindings::TgradeMsg;
+use tg_bindings::{TgradeMsg, TgradeQuery};
 
 pub use voting::VotingContract;
 
-pub fn engagement_contract() -> Box<dyn Contract<TgradeMsg>> {
-    let contract = ContractWrapper::new(
+pub fn engagement_contract() -> Box<dyn Contract<TgradeMsg, TgradeQuery>> {
+    let contract = ContractWrapper::<_, _, _, _, _, _, _, TgradeQuery>::new(
         tg4_engagement::contract::execute,
         tg4_engagement::contract::instantiate,
         tg4_engagement::contract::query,


### PR DESCRIPTION
Closes #90.

This ended being more work than anticipated, because of the extensive `CustomQuery` param changes. This is required by a bound on `TgradeApp`, part of tgrade multi-test. @hashedone  and @uint , please take a look, as I'm not sure there's a simpler approach here.

On the other hand, this is already done. So, we can in the end benefit from this early introduction of `CustomQuery` everywhere.

~~Creating as Draft to prevent / delay merge after 0.6.0 is released.~~ (done)

**Update**:

- The general strategy followed here is to try to use a generic `CustomQuery` type parameter. Specifying it as `TgradeQuery` only when needed (i.e. in entry points). That way, unit tests can still call functions using `Empty` for simplicity. There exists the possibility to extending this generality to entry points as well. Basically, by extending our `entry_point` procedural macro to accept a query parameter, and doing the renaming for us. This would allow calling the entry points using `Empty` as query type. Will create an issue to explore / document this approach.
- Multitests relying on `TgradeApp` must  now (since cw-plus 0.12.1) use `TgradeQuery`. I'm a little worried that **our (multi-) test environment is putting requirements on our contracts API**. It is supposed to be the other way around. But, I don't see an easy way out; at least for for the moment (See https://github.com/CosmWasm/cw-plus/pull/660#issuecomment-1043177477 and follow-ups).