### PR TITLE
Add description to tgrade-gov-reflect's Cargo.toml

### DIFF
--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -3,6 +3,7 @@ name = "tgrade-gov-reflect"
 version = "0.6.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
+description = "Implementing tgrade-gov-reflect voting contract"
 repository = "https://github.com/confio/poe-contracts"
 homepage = "https://tgrade.finance"
 license = "Apache-2.0"


### PR DESCRIPTION
Without it contract's wouldn't publish (and didn't so far).