### PR TITLE
Decustomize `tg4-group`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw4"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41445666e3f6284c72f569b2240bb52d0add94bb448e169d30ae28fe000cfaeb"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,10 +1601,9 @@ dependencies = [
  "cw-storage-plus",
  "cw-utils",
  "cw2",
+ "cw4",
  "schemars",
  "serde",
- "tg-bindings",
- "tg-utils",
  "tg4",
  "thiserror",
 ]

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -28,8 +28,6 @@ library = []
 [dependencies]
 cw-utils = "0.11.1"
 cw2 = "0.11.1"
-tg-bindings = { version = "0.6.1", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.1", path = "../../packages/utils" }
 tg4 = { version = "0.6.1", path = "../../packages/tg4" }
 cw-controllers = "0.11.1"
 cw-storage-plus = "0.11.1"

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -28,6 +28,7 @@ library = []
 [dependencies]
 cw-utils = "0.11.1"
 cw2 = "0.11.1"
+cw4 = "0.11.1"
 tg4 = { version = "0.6.1", path = "../../packages/tg4" }
 cw-controllers = "0.11.1"
 cw-storage-plus = "0.11.1"

--- a/contracts/tg4-group/src/contract.rs
+++ b/contracts/tg4-group/src/contract.rs
@@ -7,10 +7,9 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
-use tg4::{
-    Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
-    TotalPointsResponse,
-};
+
+use cw4::{MemberChangedHookMsg, MemberDiff};
+use tg4::{Member, MemberListResponse, MemberResponse, TotalPointsResponse};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};

--- a/contracts/tg4-group/src/contract.rs
+++ b/contracts/tg4-group/src/contract.rs
@@ -260,9 +260,8 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{from_slice, Api, OwnedDeps, Querier, Storage};
-    use cw_controllers::AdminError;
+    use cw_controllers::{AdminError, HookError};
     use tg4::{member_key, TOTAL_KEY};
-    use tg_utils::HookError;
 
     const INIT_ADMIN: &str = "juan";
     const USER1: &str = "somebody";
@@ -463,8 +462,8 @@ mod tests {
         let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
-        let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
-        assert!(hooks.is_empty());
+        let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
+        assert!(hooks.hooks.is_empty());
 
         let contract1 = String::from("hook1");
         let contract2 = String::from("hook2");
@@ -482,7 +481,7 @@ mod tests {
             add_msg.clone(),
         )
         .unwrap_err();
-        assert_eq!(err, ContractError::Unauthorized {});
+        assert_eq!(err, HookError::Admin(AdminError::NotAdmin {}).into());
 
         // admin can add it, and it appears in the query
         let admin_info = mock_info(INIT_ADMIN, &[]);
@@ -493,8 +492,8 @@ mod tests {
             add_msg.clone(),
         )
         .unwrap();
-        let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
-        assert_eq!(hooks, vec![contract1.clone()]);
+        let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
+        assert_eq!(hooks.hooks, vec![contract1.clone()]);
 
         // cannot remove a non-registered contract
         let remove_msg = ExecuteMsg::RemoveHook {
@@ -508,8 +507,8 @@ mod tests {
             addr: contract2.clone(),
         };
         let _ = execute(deps.as_mut(), mock_env(), admin_info.clone(), add_msg2).unwrap();
-        let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
-        assert_eq!(hooks, vec![contract1.clone(), contract2.clone()]);
+        let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
+        assert_eq!(hooks.hooks, vec![contract1.clone(), contract2.clone()]);
 
         // cannot re-add an existing contract
         let err = execute(deps.as_mut(), mock_env(), admin_info.clone(), add_msg).unwrap_err();
@@ -518,12 +517,12 @@ mod tests {
         // non-admin cannot remove
         let remove_msg = ExecuteMsg::RemoveHook { addr: contract1 };
         let err = execute(deps.as_mut(), mock_env(), user_info, remove_msg.clone()).unwrap_err();
-        assert_eq!(err, ContractError::Unauthorized {});
+        assert_eq!(err, HookError::Admin(AdminError::NotAdmin {}).into());
 
         // remove the original
         let _ = execute(deps.as_mut(), mock_env(), admin_info, remove_msg).unwrap();
-        let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
-        assert_eq!(hooks, vec![contract2]);
+        let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
+        assert_eq!(hooks.hooks, vec![contract2]);
     }
 
     #[test]
@@ -531,8 +530,8 @@ mod tests {
         let mut deps = mock_dependencies();
         do_instantiate(deps.as_mut());
 
-        let hooks = HOOKS.list_hooks(&deps.storage).unwrap();
-        assert!(hooks.is_empty());
+        let hooks = HOOKS.query_hooks(deps.as_ref()).unwrap();
+        assert!(hooks.hooks.is_empty());
 
         let contract1 = String::from("hook1");
         let contract2 = String::from("hook2");

--- a/contracts/tg4-group/src/contract.rs
+++ b/contracts/tg4-group/src/contract.rs
@@ -1,24 +1,20 @@
-use crate::ContractError::Unauthorized;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    attr, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Order, StdResult,
+    attr, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult,
+    SubMsg,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
 use tg4::{
-    HooksResponse, Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
+    Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
     TotalPointsResponse,
 };
-use tg_bindings::TgradeMsg;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::{ADMIN, HOOKS, MEMBERS, TOTAL};
-
-pub type Response = cosmwasm_std::Response<TgradeMsg>;
-pub type SubMsg = cosmwasm_std::SubMsg<TgradeMsg>;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:tg4-group";
@@ -80,8 +76,12 @@ pub fn execute(
         ExecuteMsg::UpdateMembers { add, remove } => {
             execute_update_members(deps, env, info, add, remove)
         }
-        ExecuteMsg::AddHook { addr } => execute_add_hook(deps, info, addr),
-        ExecuteMsg::RemoveHook { addr } => execute_remove_hook(deps, info, addr),
+        ExecuteMsg::AddHook { addr } => {
+            Ok(HOOKS.execute_add_hook(&ADMIN, deps, info, api.addr_validate(&addr)?)?)
+        }
+        ExecuteMsg::RemoveHook { addr } => {
+            Ok(HOOKS.execute_remove_hook(&ADMIN, deps, info, api.addr_validate(&addr)?)?)
+        }
     }
 }
 
@@ -108,52 +108,6 @@ pub fn execute_update_members(
     Ok(Response::new()
         .add_submessages(messages)
         .add_attributes(attributes))
-}
-
-pub fn execute_add_hook(
-    deps: DepsMut,
-    info: MessageInfo,
-    hook: String,
-) -> Result<Response, ContractError> {
-    // Same as cw4-group guard: being admin
-    if !ADMIN.is_admin(deps.as_ref(), &info.sender)? {
-        return Err(Unauthorized {});
-    }
-
-    // add the hook
-    HOOKS.add_hook(deps.storage, deps.api.addr_validate(&hook)?)?;
-
-    // response
-    let res = Response::new()
-        .add_attribute("action", "add_hook")
-        .add_attribute("hook", hook)
-        .add_attribute("sender", info.sender);
-    Ok(res)
-}
-
-pub fn execute_remove_hook(
-    deps: DepsMut,
-    info: MessageInfo,
-    hook: String,
-) -> Result<Response, ContractError> {
-    // custom guard: self-removal OR being admin
-    let hook_addr = deps.api.addr_validate(&hook)?;
-    if info.sender != hook_addr && !ADMIN.is_admin(deps.as_ref(), &info.sender)? {
-        // return Err(ContractError::Unauthorized(
-        //     "Hook address is not same as sender's or sender is not an admin".to_owned(),
-        // ));
-        return Err(ContractError::Unauthorized {});
-    }
-
-    // remove the hook
-    HOOKS.remove_hook(deps.storage, hook_addr)?;
-
-    // response
-    let resp = Response::new()
-        .add_attribute("action", "remove_hook")
-        .add_attribute("hook", hook)
-        .add_attribute("sender", info.sender);
-    Ok(resp)
 }
 
 // the logic from execute_update_members extracted for easier import
@@ -207,10 +161,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::TotalPoints {} => to_binary(&query_total_points(deps)?),
         QueryMsg::Admin {} => to_binary(&ADMIN.query_admin(deps)?),
-        QueryMsg::Hooks {} => {
-            let hooks = HOOKS.list_hooks(deps.storage)?;
-            to_binary(&HooksResponse { hooks })
-        }
+        QueryMsg::Hooks {} => to_binary(&HOOKS.query_hooks(deps)?),
     }
 }
 

--- a/contracts/tg4-group/src/error.rs
+++ b/contracts/tg4-group/src/error.rs
@@ -1,8 +1,7 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
 
-use cw_controllers::AdminError;
-use tg_utils::HookError;
+use cw_controllers::{AdminError, HookError};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {

--- a/contracts/tg4-group/src/state.rs
+++ b/contracts/tg4-group/src/state.rs
@@ -1,8 +1,7 @@
 use cosmwasm_std::Addr;
-use cw_controllers::Admin;
+use cw_controllers::{Admin, Hooks};
 use cw_storage_plus::{Item, SnapshotMap, Strategy};
 use tg4::TOTAL_KEY;
-use tg_utils::Hooks;
 
 pub const ADMIN: Admin = Admin::new("admin");
 pub const HOOKS: Hooks = Hooks::new("tg4-hooks");


### PR DESCRIPTION
By using `cw4::MemberChangedHookResponse` and  `cw4::MemberDiff` instead of their tgrade counterparts, we can easily "decustomize" this entire contract.