### PR TITLE
Valset tie-breaking #3

### DIFF
--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -759,15 +759,11 @@ fn query_member<Q: CustomQuery>(
     height: Option<u64>,
 ) -> StdResult<MemberResponse> {
     let addr = deps.api.addr_validate(&addr)?;
-    let points = match height {
+    let mi = match height {
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
-    }?
-    .map(|mi| mi.points);
-    Ok(MemberResponse {
-        points,
-        start_height: None,
-    })
+    }?;
+    Ok(mi.into())
 }
 
 pub fn query_withdrawable_rewards<Q: CustomQuery>(

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -960,10 +960,12 @@ mod tests {
                 Member {
                     addr: USER1.into(),
                     points: USER1_POINTS,
+                    start_height: None,
                 },
                 Member {
                     addr: USER2.into(),
                     points: USER2_POINTS,
+                    start_height: None,
                 },
             ],
             preauths_hooks: 1,
@@ -1047,11 +1049,13 @@ mod tests {
             vec![
                 Member {
                     addr: USER1.into(),
-                    points: 11
+                    points: 11,
+                    start_height: None
                 },
                 Member {
                     addr: USER2.into(),
-                    points: 6
+                    points: 6,
+                    start_height: None
                 },
             ]
         );
@@ -1064,7 +1068,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER1.into(),
-                points: 11
+                points: 11,
+                start_height: None
             },]
         );
 
@@ -1079,7 +1084,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER2.into(),
-                points: 6
+                points: 6,
+                start_height: None
             },]
         );
 
@@ -1106,11 +1112,13 @@ mod tests {
             vec![
                 Member {
                     addr: USER1.into(),
-                    points: 11
+                    points: 11,
+                    start_height: None
                 },
                 Member {
                     addr: USER2.into(),
-                    points: 6
+                    points: 6,
+                    start_height: None
                 }
             ]
         );
@@ -1125,7 +1133,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER1.into(),
-                points: 11
+                points: 11,
+                start_height: None
             },]
         );
 
@@ -1140,7 +1149,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER2.into(),
-                points: 6
+                points: 6,
+                start_height: None
             },]
         );
 
@@ -1187,10 +1197,12 @@ mod tests {
                 Member {
                     addr: USER1.into(),
                     points: USER1_POINTS,
+                    start_height: None,
                 },
                 Member {
                     addr: USER2.into(),
                     points: USER2_POINTS,
+                    start_height: None,
                 },
             ],
             preauths_hooks: 1,
@@ -1267,6 +1279,7 @@ mod tests {
         let add = vec![Member {
             addr: USER3.into(),
             points: 15,
+            start_height: None,
         }];
         let remove = vec![USER1.into()];
 
@@ -1308,6 +1321,7 @@ mod tests {
         let add = vec![Member {
             addr: USER1.into(),
             points: 4,
+            start_height: None,
         }];
         let remove = vec![USER3.into()];
 
@@ -1330,10 +1344,12 @@ mod tests {
             Member {
                 addr: USER1.into(),
                 points: 20,
+                start_height: None,
             },
             Member {
                 addr: USER3.into(),
                 points: 5,
+                start_height: None,
             },
         ];
         let remove = vec![USER1.into()];
@@ -1355,6 +1371,7 @@ mod tests {
         let add = Member {
             addr: USER3.into(),
             points: 15,
+            start_height: None,
         };
 
         let env = mock_env();
@@ -1390,6 +1407,7 @@ mod tests {
         let add = Member {
             addr: USER2.into(),
             points: 1,
+            start_height: None,
         };
 
         let env = mock_env();
@@ -1523,10 +1541,12 @@ mod tests {
             Member {
                 addr: USER1.into(),
                 points: 20,
+                start_height: None,
             },
             Member {
                 addr: USER3.into(),
                 points: 5,
+                start_height: None,
             },
         ];
         let remove = vec![USER2.into()];

--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -193,7 +193,8 @@ mod tests {
         assert_eq!(
             SudoMsg::UpdateMember(Member {
                 addr: "xxx".to_string(),
-                points: 123
+                points: 123,
+                start_height: None
             }),
             cosmwasm_std::from_slice::<SudoMsg>(message.as_bytes()).unwrap()
         );

--- a/contracts/tg4-engagement/src/multitest.rs
+++ b/contracts/tg4-engagement/src/multitest.rs
@@ -11,6 +11,7 @@ fn member(addr: &str, points: u64) -> Member {
     Member {
         addr: addr.to_owned(),
         points,
+        start_height: None,
     }
 }
 

--- a/contracts/tg4-engagement/src/multitest/suite.rs
+++ b/contracts/tg4-engagement/src/multitest/suite.rs
@@ -26,6 +26,7 @@ pub fn expected_members(members: Vec<(&str, u64)>) -> Vec<Member> {
         .map(|(addr, points)| Member {
             addr: addr.to_owned(),
             points,
+            start_height: None,
         })
         .collect()
 }
@@ -46,6 +47,7 @@ impl SuiteBuilder {
         self.members.push(Member {
             addr: addr.to_owned(),
             points,
+            start_height: None,
         });
         self
     }
@@ -212,6 +214,7 @@ impl Suite {
             .map(|(addr, points)| Member {
                 addr: (*addr).to_owned(),
                 points: *points,
+                start_height: None,
             })
             .collect();
 

--- a/contracts/tg4-group/src/contract.rs
+++ b/contracts/tg4-group/src/contract.rs
@@ -175,7 +175,10 @@ fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<Memb
         Some(h) => MEMBERS.may_load_at_height(deps.storage, &addr, h),
         None => MEMBERS.may_load(deps.storage, &addr),
     }?;
-    Ok(MemberResponse { points })
+    Ok(MemberResponse {
+        points,
+        start_height: None,
+    })
 }
 
 // settings for pagination
@@ -198,6 +201,7 @@ fn list_members(
             item.map(|(addr, points)| Member {
                 addr: addr.into(),
                 points,
+                start_height: None,
             })
         })
         .collect::<StdResult<_>>()?;
@@ -225,10 +229,12 @@ mod tests {
                 Member {
                     addr: USER1.into(),
                     points: 11,
+                    start_height: None,
                 },
                 Member {
                     addr: USER2.into(),
                     points: 6,
+                    start_height: None,
                 },
             ],
         };
@@ -309,6 +315,7 @@ mod tests {
         let add = vec![Member {
             addr: USER3.into(),
             points: 15,
+            start_height: None,
         }];
         let remove = vec![USER1.into()];
 
@@ -358,6 +365,7 @@ mod tests {
         let add = vec![Member {
             addr: USER1.into(),
             points: 4,
+            start_height: None,
         }];
         let remove = vec![USER3.into()];
 
@@ -385,10 +393,12 @@ mod tests {
             Member {
                 addr: USER1.into(),
                 points: 20,
+                start_height: None,
             },
             Member {
                 addr: USER3.into(),
                 points: 5,
+                start_height: None,
             },
         ];
         let remove = vec![USER1.into()];
@@ -504,10 +514,12 @@ mod tests {
             Member {
                 addr: USER1.into(),
                 points: 20,
+                start_height: None,
             },
             Member {
                 addr: USER3.into(),
                 points: 5,
+                start_height: None,
             },
         ];
         let remove = vec![USER2.into()];

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -219,10 +219,10 @@ pub fn update_members<Q: CustomQuery>(
         // to calculate this, we need to load the old points before saving the new points
         let prev_points = mems.may_load(deps.storage, &member_addr)?;
         // convenience unwrap or default
-        let points = prev_points.clone().unwrap_or_default();
-        total -= points.points;
+        let prev_points_unwrap = prev_points.clone().unwrap_or_default();
+        total -= prev_points_unwrap.points;
         total += new_points.unwrap_or_default();
-        let prev_height = points.start_height.unwrap_or(i64::MAX as u64 + 1); // Default shouldn't be needed
+        let prev_height = prev_points_unwrap.start_height.unwrap_or(height);
 
         // store the new value
         match new_points {
@@ -1152,7 +1152,7 @@ mod tests {
                     Member {
                         addr: VOTER2.into(),
                         points: 1000,
-                        start_height: Some(i64::MAX as u64 + 1)
+                        start_height: Some(12348) // VOTER2 should come first, lexicographically (descending order)
                     },
                 ]
             }

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -426,12 +426,7 @@ fn query_member<Q: CustomQuery>(
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
     }?;
-    let points = mi.as_ref().map(|mi| mi.points);
-    let start_height = mi.map(|mi| mi.start_height).unwrap_or(None);
-    Ok(MemberResponse {
-        points,
-        start_height,
-    })
+    Ok(mi.into())
 }
 
 // settings for pagination

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -1109,7 +1109,9 @@ mod tests {
             .into(),
         )
         .unwrap();
-        let msg = tg4_stake::msg::ExecuteMsg::Bond {};
+        let msg = tg4_stake::msg::ExecuteMsg::Bond {
+            vesting_tokens: None,
+        };
         app.execute_contract(Addr::unchecked(VOTER2), staker_addr, &msg, &balance)
             .unwrap();
 

--- a/contracts/tg4-mixer/src/lib.rs
+++ b/contracts/tg4-mixer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod error;
 pub mod functions;
+pub mod member_indexes;
 pub mod msg;
 pub mod state;

--- a/contracts/tg4-mixer/src/member_indexes.rs
+++ b/contracts/tg4-mixer/src/member_indexes.rs
@@ -32,13 +32,7 @@ impl<'a> IndexList<MemberInfo> for MemberIndexes<'a> {
 pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, MemberInfo, MemberIndexes<'a>> {
     let indexes = MemberIndexes {
         points_tie_break: MultiIndex::new(
-            |mi| {
-                (
-                    mi.points,
-                    mi.start_height
-                        .map_or(i64::MIN, |h| (h as i64).wrapping_neg()),
-                )
-            }, // Works as long as `start_height <= i64::MAX + 1`
+            |mi| (mi.points, mi.start_height.map_or(i64::MIN, |h| -(h as i64))), // Works as long as `start_height <= i64::MAX + 1`
             tg4::MEMBERS_KEY,
             "members__points_tie_break",
         ),

--- a/contracts/tg4-mixer/src/member_indexes.rs
+++ b/contracts/tg4-mixer/src/member_indexes.rs
@@ -1,0 +1,55 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::{Index, IndexList, IndexedSnapshotMap, MultiIndex, Strategy};
+
+use tg4::MemberInfo;
+
+// Copied from `tg-utils` and re-defined here for the extra tie-break index
+pub struct MemberIndexes<'a> {
+    // Points (multi-)indexes (deserializing the (hidden) pk to Addr)
+    pub points: MultiIndex<'a, u64, MemberInfo, Addr>,
+    pub points_tie_break: MultiIndex<'a, (u64, i64), MemberInfo, Addr>,
+}
+
+impl<'a> IndexList<MemberInfo> for MemberIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<MemberInfo>> + '_> {
+        let v: Vec<&dyn Index<MemberInfo>> = vec![&self.points, &self.points_tie_break];
+        Box::new(v.into_iter())
+    }
+}
+
+/// Indexed snapshot map for members.
+///
+/// - The map primary key is `Addr`, and the value is a tuple of `points`, `start_height` values.
+/// - The `points` index is a `MultiIndex`, as there can be multiple members with the
+/// same points.
+/// - The `(points, -start_height)` index is a `MultiIndex`, as there can be multiple members with the
+/// same points, added at the same block height.
+/// The second tuple element of the tie-breaking index is negative, so that lower heights
+/// (older members) are sorted first, as this will be used as a descending index.
+///
+/// This allows to query the map members, sorted by points, breaking ties by height, if needed
+/// (breaking ties by address in turn).
+/// The indexes are not snapshotted; only the current points are indexed at any given time.
+pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, MemberInfo, MemberIndexes<'a>> {
+    let indexes = MemberIndexes {
+        points: MultiIndex::new(|mi| mi.points, tg4::MEMBERS_KEY, "members__points"),
+        points_tie_break: MultiIndex::new(
+            |mi| {
+                (
+                    mi.points,
+                    mi.start_height
+                        .map_or(i64::MIN, |h| (h as i64).wrapping_neg()),
+                )
+            }, // Works as long as `start_height <= i64::MAX + 1`
+            tg4::MEMBERS_KEY,
+            "members__points_tie_break",
+        ),
+    };
+    IndexedSnapshotMap::new(
+        tg4::MEMBERS_KEY,
+        tg4::MEMBERS_CHECKPOINTS,
+        tg4::MEMBERS_CHANGELOG,
+        Strategy::EveryBlock,
+        indexes,
+    )
+}

--- a/contracts/tg4-mixer/src/member_indexes.rs
+++ b/contracts/tg4-mixer/src/member_indexes.rs
@@ -6,13 +6,12 @@ use tg4::MemberInfo;
 // Copied from `tg-utils` and re-defined here for the extra tie-break index
 pub struct MemberIndexes<'a> {
     // Points (multi-)indexes (deserializing the (hidden) pk to Addr)
-    pub points: MultiIndex<'a, u64, MemberInfo, Addr>,
     pub points_tie_break: MultiIndex<'a, (u64, i64), MemberInfo, Addr>,
 }
 
 impl<'a> IndexList<MemberInfo> for MemberIndexes<'a> {
     fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<MemberInfo>> + '_> {
-        let v: Vec<&dyn Index<MemberInfo>> = vec![&self.points, &self.points_tie_break];
+        let v: Vec<&dyn Index<MemberInfo>> = vec![&self.points_tie_break];
         Box::new(v.into_iter())
     }
 }
@@ -32,7 +31,6 @@ impl<'a> IndexList<MemberInfo> for MemberIndexes<'a> {
 /// The indexes are not snapshotted; only the current points are indexed at any given time.
 pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, MemberInfo, MemberIndexes<'a>> {
     let indexes = MemberIndexes {
-        points: MultiIndex::new(|mi| mi.points, tg4::MEMBERS_KEY, "members__points"),
         points_tie_break: MultiIndex::new(
             |mi| {
                 (

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -623,7 +623,10 @@ fn query_member<Q: CustomQuery>(
         None => members().may_load(deps.storage, &addr),
     }?
     .map(|mi| mi.points);
-    Ok(MemberResponse { points })
+    Ok(MemberResponse {
+        points,
+        start_height: None,
+    })
 }
 
 // settings for pagination
@@ -643,10 +646,17 @@ fn list_members<Q: CustomQuery>(
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
         .map(|item| {
-            let (addr, MemberInfo { points, .. }) = item?;
+            let (
+                addr,
+                MemberInfo {
+                    points,
+                    start_height,
+                },
+            ) = item?;
             Ok(Member {
                 addr: addr.into(),
                 points,
+                start_height,
             })
         })
         .collect();
@@ -674,10 +684,17 @@ fn list_members_by_points<Q: CustomQuery>(
         .range(deps.storage, None, start, Order::Descending)
         .take(limit)
         .map(|item| {
-            let (addr, MemberInfo { points, .. }) = item?;
+            let (
+                addr,
+                MemberInfo {
+                    points,
+                    start_height,
+                },
+            ) = item?;
             Ok(Member {
                 addr: addr.into(),
                 points,
+                start_height,
             })
         })
         .collect();
@@ -1041,11 +1058,13 @@ mod tests {
             vec![
                 Member {
                     addr: USER1.into(),
-                    points: 12
+                    points: 12,
+                    start_height: None
                 },
                 Member {
                     addr: USER2.into(),
-                    points: 7
+                    points: 7,
+                    start_height: None
                 },
             ]
         );
@@ -1058,7 +1077,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER1.into(),
-                points: 12
+                points: 12,
+                start_height: None
             },]
         );
 
@@ -1073,7 +1093,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER2.into(),
-                points: 7
+                points: 7,
+                start_height: None
             },]
         );
 
@@ -1102,15 +1123,18 @@ mod tests {
             vec![
                 Member {
                     addr: USER1.into(),
-                    points: 11
+                    points: 11,
+                    start_height: None
                 },
                 Member {
                     addr: USER2.into(),
-                    points: 6
+                    points: 6,
+                    start_height: None
                 },
                 Member {
                     addr: USER3.into(),
-                    points: 5
+                    points: 5,
+                    start_height: None
                 }
             ]
         );
@@ -1125,7 +1149,8 @@ mod tests {
             members,
             vec![Member {
                 addr: USER1.into(),
-                points: 11
+                points: 11,
+                start_height: None
             },]
         );
 
@@ -1142,11 +1167,13 @@ mod tests {
             vec![
                 Member {
                     addr: USER2.into(),
-                    points: 6
+                    points: 6,
+                    start_height: None
                 },
                 Member {
                     addr: USER3.into(),
-                    points: 5
+                    points: 5,
+                    start_height: None
                 }
             ]
         );

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -618,15 +618,11 @@ fn query_member<Q: CustomQuery>(
     height: Option<u64>,
 ) -> StdResult<MemberResponse> {
     let addr = deps.api.addr_validate(&addr)?;
-    let points = match height {
+    let mi = match height {
         Some(h) => members().may_load_at_height(deps.storage, &addr, h),
         None => members().may_load(deps.storage, &addr),
-    }?
-    .map(|mi| mi.points);
-    Ok(MemberResponse {
-        points,
-        start_height: None,
-    })
+    }?;
+    Ok(mi.into())
 }
 
 // settings for pagination

--- a/contracts/tgrade-community-pool/src/multitest/suite.rs
+++ b/contracts/tgrade-community-pool/src/multitest/suite.rs
@@ -53,6 +53,7 @@ impl SuiteBuilder {
         self.group_members.push(Member {
             addr: addr.to_owned(),
             points,
+            start_height: None,
         });
         self
     }
@@ -148,6 +149,7 @@ impl SuiteBuilder {
                     add: vec![Member {
                         addr: contract.to_string(),
                         points: self.contract_points,
+                        start_height: None,
                     }],
                 },
                 &[],

--- a/contracts/tgrade-validator-voting/src/multitest/suite.rs
+++ b/contracts/tgrade-validator-voting/src/multitest/suite.rs
@@ -61,6 +61,7 @@ impl SuiteBuilder {
         self.group_members.push(Member {
             addr: addr.to_owned(),
             points,
+            start_height: None,
         });
         self
     }

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -841,6 +841,7 @@ fn calculate_diff(
             let member = Member {
                 addr: vi.operator.to_string(),
                 points: vi.power,
+                start_height: None,
             };
 
             (update, member)
@@ -1069,6 +1070,7 @@ mod test {
             .map(|(addr, points)| Member {
                 addr: addr.to_owned(),
                 points,
+                start_height: None,
             })
             .collect()
     }

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -181,6 +181,7 @@ impl SuiteBuilder {
                 .map(|(addr, points)| Member {
                     addr: (*addr).to_owned(),
                     points: *points,
+                    start_height: None,
                 })
                 .collect(),
             halflife: halflife.into(),
@@ -227,7 +228,11 @@ impl SuiteBuilder {
 
                 let members = members
                     .into_iter()
-                    .map(|(addr, points)| Member { addr, points })
+                    .map(|(addr, points)| Member {
+                        addr,
+                        points,
+                        start_height: None,
+                    })
                     .collect();
 
                 app.instantiate_contract(

--- a/packages/tg4/src/helpers.rs
+++ b/packages/tg4/src/helpers.rs
@@ -10,7 +10,8 @@ use tg_bindings::TgradeMsg;
 use crate::msg::Tg4ExecuteMsg;
 use crate::query::HooksResponse;
 use crate::{
-    member_key, AdminResponse, Member, MemberListResponse, MemberResponse, Tg4QueryMsg, TOTAL_KEY,
+    member_key, AdminResponse, Member, MemberInfo, MemberListResponse, MemberResponse, Tg4QueryMsg,
+    TOTAL_KEY,
 };
 
 pub type SubMsg = cosmwasm_std::SubMsg<TgradeMsg>;
@@ -118,7 +119,7 @@ impl Tg4Contract {
                 if value.is_empty() {
                     Ok(None)
                 } else {
-                    from_slice(&value)
+                    Ok(from_slice::<MemberInfo>(&value)?.points.into())
                 }
             }
         }

--- a/packages/tg4/src/lib.rs
+++ b/packages/tg4/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::helpers::Tg4Contract;
 pub use crate::hook::{MemberChangedHookMsg, MemberDiff};
 pub use crate::msg::Tg4ExecuteMsg;
 pub use crate::query::{
-    member_key, AdminResponse, HooksResponse, Member, MemberListResponse, MemberResponse,
-    Tg4QueryMsg, TotalPointsResponse, MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS, MEMBERS_KEY,
-    TOTAL_KEY,
+    member_key, AdminResponse, HooksResponse, Member, MemberInfo, MemberListResponse,
+    MemberResponse, Tg4QueryMsg, TotalPointsResponse, MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS,
+    MEMBERS_KEY, TOTAL_KEY,
 };

--- a/packages/tg4/src/query.rs
+++ b/packages/tg4/src/query.rs
@@ -33,6 +33,21 @@ pub struct AdminResponse {
     pub admin: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Debug)]
+pub struct MemberInfo {
+    pub points: u64,
+    pub start_height: Option<u64>,
+}
+
+impl MemberInfo {
+    pub fn new(points: u64) -> Self {
+        Self {
+            points,
+            start_height: None,
+        }
+    }
+}
+
 /// A group member has some points associated with them.
 /// This may all be equal, or may have meaning in the app that
 /// makes use of the group (eg. voting power)

--- a/packages/tg4/src/query.rs
+++ b/packages/tg4/src/query.rs
@@ -62,6 +62,7 @@ impl MemberInfo {
 pub struct Member {
     pub addr: String,
     pub points: u64,
+    pub start_height: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -72,6 +73,7 @@ pub struct MemberListResponse {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct MemberResponse {
     pub points: Option<u64>,
+    pub start_height: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/tg4/src/query.rs
+++ b/packages/tg4/src/query.rs
@@ -76,6 +76,21 @@ pub struct MemberResponse {
     pub start_height: Option<u64>,
 }
 
+impl From<Option<MemberInfo>> for MemberResponse {
+    fn from(mi: Option<MemberInfo>) -> Self {
+        match mi {
+            None => Self {
+                points: None,
+                start_height: None,
+            },
+            Some(mi) => Self {
+                points: Some(mi.points),
+                start_height: mi.start_height,
+            },
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct TotalPointsResponse {
     pub points: u64,

--- a/packages/tg4/src/query.rs
+++ b/packages/tg4/src/query.rs
@@ -46,6 +46,13 @@ impl MemberInfo {
             start_height: None,
         }
     }
+
+    pub fn new_with_height(points: u64, height: u64) -> Self {
+        Self {
+            points,
+            start_height: Some(height),
+        }
+    }
 }
 
 /// A group member has some points associated with them.

--- a/packages/voting-contract/src/lib.rs
+++ b/packages/voting-contract/src/lib.rs
@@ -419,7 +419,7 @@ pub fn list_voters<Q: CustomQuery>(
         .group_contract
         .list_members(&deps.querier, start_after, limit)?
         .into_iter()
-        .map(|Member { addr, points }| VoterDetail { addr, points })
+        .map(|Member { addr, points, .. }| VoterDetail { addr, points })
         .collect();
     Ok(VoterListResponse { voters })
 }

--- a/packages/voting-contract/src/multitest/suite.rs
+++ b/packages/voting-contract/src/multitest/suite.rs
@@ -43,6 +43,7 @@ impl SuiteBuilder {
         self.members.push(Member {
             addr: addr.to_owned(),
             points,
+            start_height: None,
         });
         self
     }
@@ -127,6 +128,7 @@ impl Suite {
             .map(|(addr, points)| Member {
                 addr: (*addr).to_owned(),
                 points: *points,
+                start_height: None,
             })
             .collect();
 


### PR DESCRIPTION
Third attempt at closing #22. Follows the plan outlined in https://github.com/confio/poe-contracts/issues/22#issuecomment-1046852028.

TODO:

-  ~~Removing (or not) the optional `start_height` from `MemberResponse`, for simplicity.~~ (not removing)