### PR TITLE
Release 0.6.2-patch1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "tg3"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.6.2"
+version = "0.6.2-patch1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.11.1"
 cw2 = "0.11.1"
 cw-controllers = "0.11.1"
 cw-storage-plus = "0.11.1"
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
-tg-utils = { version = "0.6.2", path = "../../packages/utils" }
-tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2-patch1" }
+tg-utils = { version = "0.6.2-patch1", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.2-patch1", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta5" }
 cw-multi-test = { version = "0.11.1" }
-tg-bindings-test = { version = "0.6.2", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.6.2-patch1", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-group"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Mauro Lacy <mauro@confio.gmbh>"]
 edition = "2018"
 description = "Simple tg4 implementation of group membership controlled by admin"
@@ -29,7 +29,7 @@ library = []
 cw-utils = "0.11.1"
 cw2 = "0.11.1"
 cw4 = "0.11.1"
-tg4 = { version = "0.6.2", path = "../../packages/tg4" }
+tg4 = { version = "0.6.2-patch1", path = "../../packages/tg4" }
 cw-controllers = "0.11.1"
 cw-storage-plus = "0.11.1"
 cosmwasm-std = { version = "1.0.0-beta5" }

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.11.1"
 cw2 = "0.11.1"
 cw20 = "0.11.1"
 cw-storage-plus = "0.11.1"
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
-tg-utils = { path = "../../packages/utils", version = "0.6.2" }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.2" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2-patch1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.2-patch1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.2-patch1" }
 cosmwasm-std = "1.0.0-beta5"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -46,8 +46,8 @@ cw-multi-test = { version = "0.11.1" }
 cosmwasm-schema = { version = "1.0.0-beta5" }
 # version's workaround for issue with cyclic dependencies during cargo publish
 # https://github.com/rust-lang/cargo/issues/4242
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.2", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.6.2", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.2-patch1", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.6.2-patch1", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.11.1"
 cw2 = "0.11.1"
 cw-controllers = "0.11.1"
 cw-storage-plus = "0.11.1"
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
-tg-utils = { path = "../../packages/utils", version = "0.6.2" }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.2" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2-patch1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.2-patch1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.2-patch1" }
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -18,19 +18,19 @@ library = []
 
 [dependencies]
 cw2 = "0.11.1"
-tg3 = { path = "../../packages/tg3", version = "0.6.2" }
+tg3 = { path = "../../packages/tg3", version = "0.6.2-patch1" }
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.2" }
-tg-utils = { path = "../../packages/utils", version = "0.6.2" }
-tg-voting-contract = { version = "0.6.2", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.2", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.2-patch1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.2-patch1" }
+tg-voting-contract = { version = "0.6.2-patch1", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.2-patch1", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta5"
 cw-multi-test = "0.11.1"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2" }
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2-patch1" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2-patch1" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/confio/poe-contracts"
@@ -25,7 +25,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta5"
 cw-storage-plus = "0.11.1"
-tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
+tg-bindings = { version = "0.6.2-patch1", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -18,13 +18,13 @@ library = []
 
 [dependencies]
 cw2 = "0.11.1"
-tg3 = { path = "../../packages/tg3", version = "0.6.2" }
+tg3 = { path = "../../packages/tg3", version = "0.6.2-patch1" }
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.6.2" }
-tg-utils = { path = "../../packages/utils", version = "0.6.2" }
-tg-voting-contract = { version = "0.6.2", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.6.2-patch1" }
+tg-utils = { path = "../../packages/utils", version = "0.6.2-patch1" }
+tg-voting-contract = { version = "0.6.2-patch1", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta5"
 cw-multi-test = "0.11.1"
 cw-storage-plus = "0.11.1"
-tg-bindings-test = { version = "0.6.2", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.6.2", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.6.2", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.2", features = ["library"] }
+tg-bindings-test = { version = "0.6.2-patch1", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.6.2-patch1", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.6.2-patch1", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2-patch1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.2-patch1", features = ["library"] }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -29,9 +29,9 @@ integration = ["bech32", "cosmwasm-vm"]
 [dependencies]
 cw-utils = { version = "0.11.1" }
 cw2 = { version = "0.11.1" }
-tg4 = { path = "../../packages/tg4", version = "0.6.2" }
-tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.2", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.6.2-patch1" }
+tg-bindings = { version = "0.6.2-patch1", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.2-patch1", path = "../../packages/utils" }
 cw-controllers = { version = "0.11.1" }
 cw-storage-plus = { version = "0.11.1" }
 cosmwasm-std = { version = "1.0.0-beta5" }
@@ -46,10 +46,10 @@ cosmwasm-vm = { version = "1.0.0-beta5", optional = true, default-features = fal
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta5" }
 cw-multi-test = "0.11.1"
-tg4-engagement = { path = "../tg4-engagement", version = "0.6.2" }
-tg4-stake = { path = "../tg4-stake", version = "0.6.2" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.6.2-patch1" }
+tg4-stake = { path = "../tg4-stake", version = "0.6.2-patch1" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2-patch1" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.11.1"
 cw-storage-plus = "0.11.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.2", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.2-patch1", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.2-patch1", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta5"
 cw-multi-test = "0.11.1"
-tg-bindings-test = { version = "0.6.2", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.6.2-patch1", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.6.2", path = "../bindings" }
+tg-bindings = { version = "0.6.2-patch1", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta5"
-tg-voting-contract = { path = "../voting-contract", version = "0.6.2" }
+tg-voting-contract = { path = "../voting-contract", version = "0.6.2-patch1" }

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg3"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Tgrade-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.6.2", path = "../../packages/bindings" }
-tg-utils = { version = "0.6.2", path = "../../packages/utils" }
+tg-bindings = { version = "0.6.2-patch1", path = "../../packages/bindings" }
+tg-utils = { version = "0.6.2-patch1", path = "../../packages/utils" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0-beta5"

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.6.2" }
+tg-bindings = { path = "../bindings", version = "0.6.2-patch1" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta5" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.11.1"
 cw2 = "0.11.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.6.2" }
-tg-bindings = { path = "../bindings", version = "0.6.2" }
+tg4 = { path = "../tg4", version = "0.6.2-patch1" }
+tg-bindings = { path = "../bindings", version = "0.6.2-patch1" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.6.2"
+version = "0.6.2-patch1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -12,14 +12,14 @@ license = "Apache-2.0"
 
 [dependencies]
 cw-utils = "0.11.1"
-tg3 = { path = "../../packages/tg3", version = "0.6.2" }
+tg3 = { path = "../../packages/tg3", version = "0.6.2-patch1" }
 cw-storage-plus = "0.11.1"
 cosmwasm-std = "1.0.0-beta5"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.6.2" }
-tg-bindings = { path = "../bindings", version = "0.6.2" }
-tg-utils = { version = "0.6.2", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.6.2-patch1" }
+tg-bindings = { path = "../bindings", version = "0.6.2-patch1" }
+tg-utils = { version = "0.6.2-patch1", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta5"
 cw-multi-test = "0.11.1"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.2", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.6.2-patch1" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.6.2-patch1", features = ["library"] }


### PR DESCRIPTION
Just to allow trade-validator-voting to update the tfi contracts, which were instantiated with no migration admin.