### PR TITLE
Stake vesting accounts

### DIFF
--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -597,7 +597,9 @@ mod tests {
             let caller = Addr::unchecked(staker.addr);
 
             // they stake to the contract
-            let msg = tg4_stake::msg::ExecuteMsg::Bond {};
+            let msg = tg4_stake::msg::ExecuteMsg::Bond {
+                vesting_tokens: None,
+            };
             app.execute_contract(caller.clone(), contract.clone(), &msg, &balance)
                 .unwrap();
         }
@@ -774,7 +776,9 @@ mod tests {
             .into(),
         )
         .unwrap();
-        let msg = tg4_stake::msg::ExecuteMsg::Bond {};
+        let msg = tg4_stake::msg::ExecuteMsg::Bond {
+            vesting_tokens: None,
+        };
         app.execute_contract(Addr::unchecked(VOTER5), staker_addr, &msg, &balance)
             .unwrap();
 

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -1765,6 +1765,26 @@ mod tests {
         }
 
         #[test]
+        fn slashing_stake_update_membership() {
+            let mut deps = mock_deps_tgrade();
+            default_instantiate(deps.as_mut());
+            let slasher = add_slasher(deps.as_mut());
+
+            // ensure it rounds down, and respects cut-off
+            bond(deps.as_mut(), (0, 12_000), (7_000, 0), (3_000, 4_000), 1);
+            assert_users(deps.as_ref(), Some(12), Some(7), Some(7), None);
+
+            slash(deps.as_mut(), &slasher, USER1, Decimal::percent(50)).unwrap();
+            slash(deps.as_mut(), &slasher, USER2, Decimal::percent(10)).unwrap();
+            slash(deps.as_mut(), &slasher, USER3, Decimal::percent(20)).unwrap();
+
+            // Assert updated points
+            assert_stake_liquid(deps.as_ref(), 0, 6_300, 2_400);
+            assert_stake_vesting(deps.as_ref(), 6_000, 0, 3_200);
+            assert_users(deps.as_ref(), Some(6), Some(6), Some(5), None);
+        }
+
+        #[test]
         fn slashing_claims_works() {
             let mut deps = mock_deps_tgrade();
             default_instantiate(deps.as_mut());

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -410,12 +410,15 @@ pub fn sudo(
 fn privilege_promote<Q: CustomQuery>(deps: DepsMut<Q>) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
 
+    let mut res = Response::new();
     if config.auto_return_limit > 0 {
         let msgs = request_privileges(&[Privilege::EndBlocker]);
-        Ok(Response::new().add_submessages(msgs))
-    } else {
-        Ok(Response::new())
+        res = res.add_submessages(msgs);
     }
+    let msgs = request_privileges(&[Privilege::Delegator]);
+    res = res.add_submessages(msgs);
+
+    Ok(res)
 }
 
 fn end_block<Q: CustomQuery>(deps: DepsMut<Q>, env: Env) -> Result<Response, ContractError> {

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -338,41 +338,47 @@ pub fn execute_slash<Q: CustomQuery>(
         return Ok(Response::new());
     }
 
-    // slash the liquid stake, if any
-    let mut liquid_slashed = liquid_stake.map(|s| s * portion).unwrap_or_default();
-    let new_liquid_stake = STAKE.update(deps.storage, &addr, |stake| -> StdResult<_> {
-        Ok(stake.unwrap_or_default().sub(liquid_slashed))
-    })?;
-
-    // slash the vesting stake, if any
-    let vesting_slashed = vesting_stake.map(|s| s * portion).unwrap_or_default();
-    let new_vesting_stake = STAKE_VESTING.update(deps.storage, &addr, |stake| -> StdResult<_> {
-        Ok(stake.unwrap_or_default().sub(vesting_slashed))
-    })?;
-
-    // slash the claims
-    liquid_slashed += claims().slash_claims_for_addr(deps.storage, addr.clone(), portion)?;
-
     // response
     let mut res = Response::new()
         .add_attribute("action", "slash")
         .add_attribute("addr", &addr)
         .add_attribute("sender", info.sender);
 
-    // burn the liquid slashed tokens
-    if liquid_slashed > Uint128::zero() {
-        let burn_liquid_msg = BankMsg::Burn {
-            amount: coins(liquid_slashed.u128(), &cfg.denom),
-        };
-        res = res.add_message(burn_liquid_msg);
+    // slash the liquid stake, if any
+    let mut new_liquid_stake = Uint128::zero();
+    if let Some(liquid_stake) = liquid_stake {
+        let mut liquid_slashed = liquid_stake * portion;
+        new_liquid_stake = STAKE.update(deps.storage, &addr, |stake| -> StdResult<_> {
+            Ok(stake.unwrap_or_default().sub(liquid_slashed))
+        })?;
+
+        // slash the claims
+        liquid_slashed += claims().slash_claims_for_addr(deps.storage, addr.clone(), portion)?;
+
+        // burn the liquid slashed tokens
+        if liquid_slashed > Uint128::zero() {
+            let burn_liquid_msg = BankMsg::Burn {
+                amount: coins(liquid_slashed.u128(), &cfg.denom),
+            };
+            res = res.add_message(burn_liquid_msg);
+        }
     }
 
-    // burn the vesting slashed tokens
-    if vesting_slashed > Uint128::zero() {
-        let burn_vesting_msg = BankMsg::Burn {
-            amount: coins(vesting_slashed.u128(), &cfg.denom),
-        };
-        res = res.add_message(burn_vesting_msg);
+    // slash the vesting stake, if any
+    let mut new_vesting_stake = Uint128::zero();
+    if let Some(vesting_stake) = vesting_stake {
+        let vesting_slashed = vesting_stake * portion;
+        new_vesting_stake = STAKE_VESTING.update(deps.storage, &addr, |stake| -> StdResult<_> {
+            Ok(stake.unwrap_or_default().sub(vesting_slashed))
+        })?;
+
+        // burn the vesting slashed tokens
+        if vesting_slashed > Uint128::zero() {
+            let burn_vesting_msg = BankMsg::Burn {
+                amount: coins(vesting_slashed.u128(), &cfg.denom),
+            };
+            res = res.add_message(burn_vesting_msg);
+        }
     }
 
     res.messages.extend(update_membership(

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -1166,27 +1166,29 @@ mod tests {
         let height = mock_env().block.height;
 
         // ensure it rounds down, and respects cut-off
-        bond(deps.as_mut(), (0, 12_000), (500, 7_000), (2_000, 2_000), 1);
-        unbond(deps.as_mut(), 4_500, 2_600, 1_111, 2, 0);
+        bond(deps.as_mut(), (0, 12_000), (500, 7_000), (3_000, 3_000), 1);
+        assert_users(deps.as_ref(), Some(12), Some(7), Some(6), None);
+
+        unbond(deps.as_mut(), 4_500, 2_600, 1_000, 2, 0);
 
         // Assert updated points
-        assert_stake_liquid(deps.as_ref(), 0, 0, 889);
-        assert_stake_vesting(deps.as_ref(), 7_500, 4_900, 2000);
-        assert_users(deps.as_ref(), Some(7), None, None, None);
+        assert_stake_liquid(deps.as_ref(), 0, 0, 2000);
+        assert_stake_vesting(deps.as_ref(), 7_500, 4_900, 3000);
+        assert_users(deps.as_ref(), Some(7), None, Some(5), None);
 
         // Adding a little more returns points
         bond(deps.as_mut(), (500, 100), (100, 0), (0, 2_222), 3);
 
         // Assert updated points
-        assert_stake_liquid(deps.as_ref(), 500, 100, 889);
-        assert_stake_vesting(deps.as_ref(), 7_600, 4_900, 4_222);
-        assert_users(deps.as_ref(), Some(8), Some(5), Some(5), None);
+        assert_stake_liquid(deps.as_ref(), 500, 100, 2000);
+        assert_stake_vesting(deps.as_ref(), 7_600, 4_900, 5_222);
+        assert_users(deps.as_ref(), Some(8), Some(5), Some(7), None);
 
         // check historical queries all work
         assert_users(deps.as_ref(), None, None, None, Some(height + 1)); // before first stake
-        assert_users(deps.as_ref(), Some(12), Some(7), None, Some(height + 2)); // after first bond
-        assert_users(deps.as_ref(), Some(7), None, None, Some(height + 3)); // after first unbond
-        assert_users(deps.as_ref(), Some(8), Some(5), Some(5), Some(height + 4)); // after second bond
+        assert_users(deps.as_ref(), Some(12), Some(7), Some(6), Some(height + 2)); // after first bond
+        assert_users(deps.as_ref(), Some(7), None, Some(5), Some(height + 3)); // after first unbond
+        assert_users(deps.as_ref(), Some(8), Some(5), Some(7), Some(height + 4)); // after second bond
 
         // error if try to unbond more than stake (USER2 has 5000 staked)
         let msg = ExecuteMsg::Unbond {

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -1555,6 +1555,10 @@ mod tests {
         }
 
         fn assert_burned(res: Response, expected_liquid: &[Coin], expected_vesting: &[Coin]) {
+            // Args checks for robustness
+            assert!(expected_liquid.len() <= 1);
+            assert!(expected_vesting.len() <= 1);
+
             // Find all instances of BankMsg::Burn in the response and extract the burned amounts
             let burned_amounts: Vec<_> = res
                 .messages

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -174,9 +174,8 @@ pub fn execute_bond<Q: CustomQuery>(
             })?;
         // Delegate (stake to contract) to sender's vesting account
         let msg = TgradeMsg::Delegate {
-            denom: cfg.denom.clone(),
-            amount: vesting_amount,
-            sender: info.sender.to_string(),
+            funds: coin(amount.into(), cfg.denom.clone()),
+            staker: info.sender.to_string(),
         };
         res = res
             .add_message(msg)
@@ -234,8 +233,7 @@ pub fn execute_unbond<Q: CustomQuery>(
             })?;
         // Undelegate (unstake from contract) to sender's vesting account
         let msg = TgradeMsg::Undelegate {
-            denom: cfg.denom.clone(),
-            amount: vesting_amount,
+            funds: coin(vesting_amount.into(), cfg.denom.clone()),
             recipient: info.sender.to_string(),
         };
         res = res

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -578,7 +578,7 @@ pub fn query_staked<Q: CustomQuery>(deps: Deps<Q>, addr: String) -> StdResult<St
     let config = CONFIG.load(deps.storage)?;
 
     Ok(StakedResponse {
-        stake: coin(stake.u128(), config.denom.clone()),
+        liquid: coin(stake.u128(), config.denom.clone()),
         vesting: coin(vesting.u128(), config.denom),
     })
 }
@@ -875,13 +875,13 @@ mod tests {
     #[track_caller]
     fn assert_stake_liquid(deps: Deps<TgradeQuery>, user1: u128, user2: u128, user3: u128) {
         let stake1 = query_staked(deps, USER1.into()).unwrap();
-        assert_eq!(stake1.stake, coin(user1, DENOM));
+        assert_eq!(stake1.liquid, coin(user1, DENOM));
 
         let stake2 = query_staked(deps, USER2.into()).unwrap();
-        assert_eq!(stake2.stake, coin(user2, DENOM));
+        assert_eq!(stake2.liquid, coin(user2, DENOM));
 
         let stake3 = query_staked(deps, USER3.into()).unwrap();
-        assert_eq!(stake3.stake, coin(user3, DENOM));
+        assert_eq!(stake3.liquid, coin(user3, DENOM));
     }
 
     // this tests the member queries of illiquid amounts

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -1183,7 +1183,7 @@ mod tests {
         let mut deps = mock_deps_tgrade();
         default_instantiate(deps.as_mut());
         // Set values as (11, 6, None)
-        bond_liquid(deps.as_mut(), 11_000, 6_000, 0, 1);
+        bond(deps.as_mut(), (1_000, 10_000), (6_000, 0), (0, 0), 1);
 
         // get total from raw key
         let total_raw = deps.storage.get(TOTAL_KEY.as_bytes()).unwrap();
@@ -1218,8 +1218,9 @@ mod tests {
         default_instantiate(deps.as_mut());
 
         // create some data
-        bond_liquid(deps.as_mut(), 12_000, 7_500, 4_000, 1);
+        bond(deps.as_mut(), (4_000, 7_500), (7_500, 0), (3_000, 1_000), 1);
         let height_delta = 2;
+        // Only 4_000 (liquid) will be claimed for USER1
         unbond(deps.as_mut(), 4_500, 2_600, 0, height_delta, 0);
         let mut env = mock_env();
         env.block.height += height_delta;
@@ -1230,7 +1231,7 @@ mod tests {
             get_claims(deps.as_ref(), Addr::unchecked(USER1), None, None),
             vec![Claim::new(
                 Addr::unchecked(USER1),
-                4_500,
+                4_000,
                 expires,
                 env.block.height
             )]
@@ -1263,7 +1264,7 @@ mod tests {
             get_claims(deps.as_ref(), Addr::unchecked(USER1), None, None),
             vec![Claim::new(
                 Addr::unchecked(USER1),
-                4_500,
+                4_000,
                 expires,
                 env.block.height
             )]
@@ -1310,7 +1311,7 @@ mod tests {
             res.messages,
             vec![SubMsg::new(BankMsg::Send {
                 to_address: USER1.into(),
-                amount: coins(4_500, DENOM),
+                amount: coins(4_000, DENOM),
             })]
         );
 

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -42,7 +42,7 @@ pub enum ExecuteMsg {
     /// Unbond will start the unbonding process for the given number of tokens.
     /// The sender immediately loses points from these tokens, and can claim them
     /// back to his wallet after `unbonding_period`.
-    /// Tokens will be unbonded from the liquid pool first, and then from the vesting pool
+    /// Tokens will be unbonded from the liquid stake first, and then from the vesting stake
     /// if available.
     Unbond { tokens: Coin },
     /// Claim is used to claim your native tokens that you previously "unbonded"

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -37,10 +37,13 @@ pub struct InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     /// Bond will bond all staking tokens sent with the message and update membership points
-    Bond {},
+    /// The optional `vesting_tokens` will be staked (delegated) as well, if set.
+    Bond { vesting_tokens: Option<Coin> },
     /// Unbond will start the unbonding process for the given number of tokens.
     /// The sender immediately loses points from these tokens, and can claim them
-    /// back to his wallet after `unbonding_period`
+    /// back to his wallet after `unbonding_period`.
+    /// Tokens will be unbonded from the liquid pool first, and then from the vesting pool
+    /// if available.
     Unbond { tokens: Coin },
     /// Claim is used to claim your native tokens that you previously "unbonded"
     /// after the contract-defined waiting period (eg. 1 week)

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -119,6 +119,7 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct StakedResponse {
     pub stake: Coin,
+    pub vesting: Coin,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -36,7 +36,7 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    /// Bond will bond all staking tokens sent with the message and update membership points
+    /// Bond will bond all staking tokens sent with the message and update membership points.
     /// The optional `vesting_tokens` will be staked (delegated) as well, if set.
     Bond { vesting_tokens: Option<Coin> },
     /// Unbond will start the unbonding process for the given number of tokens.

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -118,7 +118,7 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct StakedResponse {
-    pub stake: Coin,
+    pub liquid: Coin,
     pub vesting: Coin,
 }
 

--- a/contracts/tg4-stake/src/state.rs
+++ b/contracts/tg4-stake/src/state.rs
@@ -25,3 +25,4 @@ pub struct Config {
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const STAKE: Map<&Addr, Uint128> = Map::new("stake");
+pub const STAKE_VESTING: Map<&Addr, Uint128> = Map::new("vesting_stake");

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -764,7 +764,9 @@ impl Suite {
         self.app.execute_contract(
             addr.clone(),
             self.membership.clone(),
-            &tg4_stake::msg::ExecuteMsg::Bond {},
+            &tg4_stake::msg::ExecuteMsg::Bond {
+                vesting_tokens: None,
+            },
             stake,
         )
     }

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -261,17 +261,15 @@ impl Module for TgradeModule {
                 router.sudo(api, storage, block, mint.into())
             }
             TgradeMsg::Delegate {
-                denom: _demon,
-                amount: _amount,
-                sender: _sender,
+                funds: _funds,
+                staker: _staker,
             } => {
                 self.require_privilege(storage, &sender, Privilege::Delegator)?;
                 // FIXME? We don't do anything here
                 Ok(AppResponse::default())
             }
             TgradeMsg::Undelegate {
-                denom: _demon,
-                amount: _amount,
+                funds: _funds,
                 recipient: _recipient,
             } => {
                 self.require_privilege(storage, &sender, Privilege::Delegator)?;

--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -260,6 +260,24 @@ impl Module for TgradeModule {
                 };
                 router.sudo(api, storage, block, mint.into())
             }
+            TgradeMsg::Delegate {
+                denom: _demon,
+                amount: _amount,
+                sender: _sender,
+            } => {
+                self.require_privilege(storage, &sender, Privilege::Delegator)?;
+                // FIXME? We don't do anything here
+                Ok(AppResponse::default())
+            }
+            TgradeMsg::Undelegate {
+                denom: _demon,
+                amount: _amount,
+                recipient: _recipient,
+            } => {
+                self.require_privilege(storage, &sender, Privilege::Delegator)?;
+                // FIXME? We don't do anything here
+                Ok(AppResponse::default())
+            }
         }
     }
 
@@ -542,4 +560,6 @@ mod tests {
             .unwrap();
         assert_eq!(end, mintable);
     }
+
+    // TODO: Delegate / Undelegate tests
 }

--- a/packages/bindings/src/hooks.rs
+++ b/packages/bindings/src/hooks.rs
@@ -21,6 +21,9 @@ pub enum Privilege {
     TokenMinter,
     /// contracts registered here are allowed to use ConsensusParams msg to adjust tendermint
     ConsensusParamChanger,
+    /// contracts registered here are allowed to use Delegate / Undelegate to stake funds using the
+    /// Cosmos SDK
+    Delegator,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Binary, CosmosMsg, CustomMsg, Uint128};
+use cosmwasm_std::{Binary, Coin, CosmosMsg, CustomMsg, Uint128};
 
 use crate::gov::GovProposal;
 use crate::hooks::PrivilegeMsg;
@@ -38,17 +38,9 @@ pub enum TgradeMsg {
         proposal: GovProposal,
     },
     /// This will stake funds from the sender's vesting account. Requires `Delegator` privilege.
-    Delegate {
-        denom: String,
-        amount: Uint128,
-        sender: String,
-    },
+    Delegate { funds: Coin, staker: String },
     /// This will unstake funds to the recipient's vesting account. Requires `Delegator` privilege.
-    Undelegate {
-        denom: String,
-        amount: Uint128,
-        recipient: String,
-    },
+    Undelegate { funds: Coin, recipient: String },
 }
 
 /// See https://github.com/tendermint/tendermint/blob/v0.34.8/proto/tendermint/abci/types.proto#L282-L289

--- a/packages/bindings/src/msg.rs
+++ b/packages/bindings/src/msg.rs
@@ -37,6 +37,18 @@ pub enum TgradeMsg {
         description: String,
         proposal: GovProposal,
     },
+    /// This will stake funds from the sender's vesting account. Requires `Delegator` privilege.
+    Delegate {
+        denom: String,
+        amount: Uint128,
+        sender: String,
+    },
+    /// This will unstake funds to the recipient's vesting account. Requires `Delegator` privilege.
+    Undelegate {
+        denom: String,
+        amount: Uint128,
+        recipient: String,
+    },
 }
 
 /// See https://github.com/tendermint/tendermint/blob/v0.34.8/proto/tendermint/abci/types.proto#L282-L289


### PR DESCRIPTION
This is the contract side of https://github.com/confio/tgrade/issues/220.

TODO:

  - [x] Query vesting stake. Make current queries return the illiquid (vesting) staked amounts too.
  - [x] Vesting account tests. Confirm the illiquid (vesting) vs. liquid staking logic works.
  - [x] ~~Delegate / Undelegate multi-tests. Some simple tests to check delegate / undelegate messages routing~~. (Unnecessary. Contract is already tested / integrated in the blockchain)
  - [x] Slashing support for vesting account. Add support for slashing illiquid (vesting) tokens along with liquid ones.

