### PR TITLE
Verify new validators are online

### DIFF
--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -21,7 +21,7 @@ use tg_bindings::{
     Pubkey, TgradeMsg, TgradeQuery, TgradeSudoMsg, ToAddress, ValidatorDiff, ValidatorUpdate,
     ValidatorVoteResponse,
 };
-use tg_utils::{ensure_from_older_version, Duration, JailingDuration, SlashMsg, ADMIN};
+use tg_utils::{ensure_from_older_version, JailingDuration, SlashMsg, ADMIN};
 
 use crate::error::ContractError;
 use crate::migration::migrate_jailing_period;
@@ -79,6 +79,7 @@ pub fn instantiate(
         // Will be overwritten in reply for rewards contract instantiation
         validator_group: Addr::unchecked(""),
         verify_validators: msg.verify_validators,
+        offline_jail_duration: msg.offline_jail_duration,
     };
     CONFIG.save(deps.storage, &cfg)?;
 
@@ -677,7 +678,7 @@ fn end_block(deps: DepsMut<TgradeQuery>, env: Env) -> Result<Response, ContractE
 
         if let Some(pending) = PENDING_VALIDATORS.may_load(deps.storage)? {
             let expiration = JailingPeriod::from_duration(
-                JailingDuration::Duration(Duration::new(600)),
+                JailingDuration::Duration(cfg.offline_jail_duration),
                 &env.block,
             );
 

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -671,12 +671,14 @@ fn end_block(deps: DepsMut<TgradeQuery>, env: Env) -> Result<Response, ContractE
     EPOCH.save(deps.storage, &epoch)?;
 
     if cfg.verify_validators {
-        let votes = deps
-            .querier
-            .query::<ValidatorVoteResponse>(&QueryRequest::Custom(TgradeQuery::ValidatorVotes {}))?
-            .votes;
-
         if let Some(pending) = PENDING_VALIDATORS.may_load(deps.storage)? {
+            let votes = deps
+                .querier
+                .query::<ValidatorVoteResponse>(&QueryRequest::Custom(
+                    TgradeQuery::ValidatorVotes {},
+                ))?
+                .votes;
+
             let expiration = JailingPeriod::from_duration(
                 JailingDuration::Duration(cfg.offline_jail_duration),
                 &env.block,

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -90,6 +90,13 @@ pub struct InstantiateMsg {
     ///
     /// This contract has to support all the `RewardsDistribution` messages
     pub validator_group_code_id: u64,
+
+    /// When a validator joins the valset, verify they sign the first block since joining
+    /// or jail them for a period otherwise.
+    ///
+    /// The verification happens every time the validator becomes an active validator,
+    /// including when they are unjailed or when they just gain enough power to participate.
+    pub verify_validators: bool,
 }
 
 impl InstantiateMsg {
@@ -532,6 +539,7 @@ mod test {
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: UnvalidatedDistributionContracts::default(),
             validator_group_code_id: 0,
+            verify_validators: false,
         };
         proper.validate().unwrap();
 

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -5,7 +5,7 @@ use std::ops::Add;
 
 use tg4::Member;
 use tg_bindings::{Ed25519Pubkey, Pubkey};
-use tg_utils::{Expiration, JailingDuration};
+use tg_utils::{Duration, Expiration, JailingDuration};
 
 use crate::error::ContractError;
 use crate::state::{DistributionContract, OperatorInfo, ValidatorInfo, ValidatorSlashing};
@@ -97,6 +97,10 @@ pub struct InstantiateMsg {
     /// The verification happens every time the validator becomes an active validator,
     /// including when they are unjailed or when they just gain enough power to participate.
     pub verify_validators: bool,
+
+    /// The duration to jail a validator for in case they don't sign their first epoch
+    /// boundary block. After the period, they have to pass verification again, ad infinitum.
+    pub offline_jail_duration: Duration,
 }
 
 impl InstantiateMsg {
@@ -540,6 +544,7 @@ mod test {
             distribution_contracts: UnvalidatedDistributionContracts::default(),
             validator_group_code_id: 0,
             verify_validators: false,
+            offline_jail_duration: Duration::new(0),
         };
         proper.validate().unwrap();
 

--- a/contracts/tgrade-valset/src/multitest.rs
+++ b/contracts/tgrade-valset/src/multitest.rs
@@ -9,3 +9,4 @@ mod slashing;
 mod stake;
 mod suite;
 mod update_config;
+mod verify_online;

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -40,6 +40,7 @@ fn initialization() {
             // This one it is basically assumed is set correctly. Other tests tests if behavior
             // of relation between those contract is correct
             validator_group: config.validator_group.clone(),
+            verify_validators: false,
         }
     );
 
@@ -431,6 +432,7 @@ mod instantiate {
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: UnvalidatedDistributionContracts::default(),
             validator_group_code_id: 1,
+            verify_validators: false,
         };
 
         let err = app

--- a/contracts/tgrade-valset/src/multitest/contract.rs
+++ b/contracts/tgrade-valset/src/multitest/contract.rs
@@ -8,6 +8,7 @@ use super::helpers::{addr_to_pubkey, assert_active_validators, assert_operators,
 use super::suite::SuiteBuilder;
 use assert_matches::assert_matches;
 use cosmwasm_std::{coin, Decimal};
+use tg_utils::Duration;
 
 #[test]
 fn initialization() {
@@ -41,6 +42,7 @@ fn initialization() {
             // of relation between those contract is correct
             validator_group: config.validator_group.clone(),
             verify_validators: false,
+            offline_jail_duration: Duration::new(0),
         }
     );
 
@@ -370,6 +372,7 @@ mod instantiate {
     use cosmwasm_std::{coin, Addr, Decimal, Uint128};
     use cw_multi_test::{AppBuilder, BasicApp, Executor};
     use tg_bindings::{TgradeMsg, TgradeQuery};
+    use tg_utils::Duration;
 
     use crate::error::ContractError;
     use crate::msg::{
@@ -433,6 +436,7 @@ mod instantiate {
             distribution_contracts: UnvalidatedDistributionContracts::default(),
             validator_group_code_id: 1,
             verify_validators: false,
+            offline_jail_duration: Duration::new(0),
         };
 
         let err = app

--- a/contracts/tgrade-valset/src/multitest/stake.rs
+++ b/contracts/tgrade-valset/src/multitest/stake.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 use cosmwasm_std::{coin, Addr, Decimal};
+use tg_utils::Duration;
 
 use crate::multitest::suite::SuiteBuilder;
 use crate::state::{Config, ValidatorInfo};
@@ -36,6 +37,7 @@ fn init_and_query_state() {
             distribution_contracts: vec![],
             validator_group: cfg.validator_group.clone(),
             verify_validators: false,
+            offline_jail_duration: Duration::new(0),
         }
     );
 

--- a/contracts/tgrade-valset/src/multitest/stake.rs
+++ b/contracts/tgrade-valset/src/multitest/stake.rs
@@ -35,6 +35,7 @@ fn init_and_query_state() {
             double_sign_slash_ratio: Decimal::percent(50),
             distribution_contracts: vec![],
             validator_group: cfg.validator_group.clone(),
+            verify_validators: false,
         }
     );
 

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 use cw_multi_test::{next_block, AppResponse, Contract, ContractWrapper, CosmosRouter, Executor};
 use derivative::Derivative;
 use tg4::{AdminResponse, Member};
-use tg_bindings::{Evidence, Pubkey, TgradeMsg, TgradeQuery, ValidatorDiff};
+use tg_bindings::{Evidence, Pubkey, TgradeMsg, TgradeQuery, ValidatorDiff, ValidatorVote};
 use tg_bindings_test::TgradeApp;
 use tg_utils::{Duration, JailingDuration};
 
@@ -100,6 +100,7 @@ pub struct SuiteBuilder {
     distribution_configs: Vec<DistributionConfig>,
     /// Funds to add on init per address
     init_funds: Vec<(String, Vec<Coin>)>,
+    verify_validators: bool,
 }
 
 impl SuiteBuilder {
@@ -161,6 +162,11 @@ impl SuiteBuilder {
 
     pub fn with_auto_unjail(mut self) -> Self {
         self.auto_unjail = true;
+        self
+    }
+
+    pub fn with_verify_validators(mut self) -> Self {
+        self.verify_validators = true;
         self
     }
 
@@ -347,7 +353,7 @@ impl SuiteBuilder {
                         inner: distribution_contract_instantiation_info,
                     },
                     validator_group_code_id: engagement_id,
-                    verify_validators: false,
+                    verify_validators: self.verify_validators,
                 },
                 &[],
                 "valset",
@@ -792,5 +798,13 @@ impl Suite {
             msg,
             self.valset_code_id,
         )
+    }
+
+    pub fn set_votes(&mut self, votes: &[ValidatorVote]) -> AnyResult<()> {
+        Ok(self
+            .app
+            .init_modules(|router, _api, storage| -> StdResult<()> {
+                router.custom.set_votes(storage, votes.to_vec())
+            })?)
     }
 }

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -347,6 +347,7 @@ impl SuiteBuilder {
                         inner: distribution_contract_instantiation_info,
                     },
                     validator_group_code_id: engagement_id,
+                    verify_validators: false,
                 },
                 &[],
                 "valset",

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -354,7 +354,9 @@ impl SuiteBuilder {
                     },
                     validator_group_code_id: engagement_id,
                     verify_validators: self.verify_validators.is_some(),
-                    offline_jail_duration: self.verify_validators.unwrap_or(Duration::new(0)),
+                    offline_jail_duration: self
+                        .verify_validators
+                        .unwrap_or_else(|| Duration::new(0)),
                 },
                 &[],
                 "valset",

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -100,7 +100,7 @@ pub struct SuiteBuilder {
     distribution_configs: Vec<DistributionConfig>,
     /// Funds to add on init per address
     init_funds: Vec<(String, Vec<Coin>)>,
-    verify_validators: bool,
+    verify_validators: Option<Duration>,
 }
 
 impl SuiteBuilder {
@@ -165,8 +165,8 @@ impl SuiteBuilder {
         self
     }
 
-    pub fn with_verify_validators(mut self) -> Self {
-        self.verify_validators = true;
+    pub fn with_verify_validators(mut self, duration: u64) -> Self {
+        self.verify_validators = Some(Duration::new(duration));
         self
     }
 
@@ -353,7 +353,8 @@ impl SuiteBuilder {
                         inner: distribution_contract_instantiation_info,
                     },
                     validator_group_code_id: engagement_id,
-                    verify_validators: self.verify_validators,
+                    verify_validators: self.verify_validators.is_some(),
+                    offline_jail_duration: self.verify_validators.unwrap_or(Duration::new(0)),
                 },
                 &[],
                 "valset",

--- a/contracts/tgrade-valset/src/multitest/verify_online.rs
+++ b/contracts/tgrade-valset/src/multitest/verify_online.rs
@@ -14,6 +14,8 @@ fn addr_to_vote_addr(addr: &str) -> Binary {
     Binary(pubkey.to_address().to_vec())
 }
 
+// Unreadable tests ahead! This deserves a refactor.
+
 #[test]
 fn verify_validators_works() {
     let members = vec![
@@ -49,7 +51,7 @@ fn verify_validators_works() {
     assert!(info1.active_validator);
     assert!(info2.active_validator);
 
-    suite.next_block().unwrap();
+    suite.advance_epoch().unwrap();
 
     let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
     let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
@@ -85,13 +87,13 @@ fn verify_validators_jailing() {
     assert!(info1.jailed_until.is_none());
     assert!(info2.jailed_until.is_none());
 
-    suite.next_block().unwrap();
+    suite.advance_epoch().unwrap();
 
     let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
     let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
     assert!(info1.jailed_until.is_none());
     assert!(info2.jailed_until.is_some());
-    // TODO: info2.active_validator is true - should it be true?
+    assert!(!info2.active_validator);
 }
 
 #[test]
@@ -103,5 +105,4 @@ fn validator_needs_to_verify_if_unjailed() {
 #[test]
 #[ignore]
 fn validator_has_minimum_power_until_verified() {
-    todo!();
-}
+    todo!()

--- a/contracts/tgrade-valset/src/multitest/verify_online.rs
+++ b/contracts/tgrade-valset/src/multitest/verify_online.rs
@@ -97,9 +97,71 @@ fn verify_validators_jailing() {
 }
 
 #[test]
-#[ignore]
 fn validator_needs_to_verify_if_unjailed() {
-    todo!();
+    let members = vec![
+        "member1member1member1member1memb",
+        "member2member2member2member2memb",
+    ];
+
+    let mut suite = SuiteBuilder::new()
+        .with_operators(&members)
+        .with_engagement(&members_init(&members, &[2, 3]))
+        .with_verify_validators(600)
+        .with_epoch_length(600)
+        .build();
+
+    suite
+        .set_votes(&[ValidatorVote {
+            address: addr_to_vote_addr(members[0]),
+            power: 2,
+            voted: true,
+        }])
+        .unwrap();
+
+    assert!(suite
+        .validator(members[1])
+        .unwrap()
+        .validator
+        .unwrap()
+        .jailed_until
+        .is_none());
+
+    suite.advance_epoch().unwrap();
+
+    // Validator 2 failed verification, so is jailed
+    assert!(suite
+        .validator(members[1])
+        .unwrap()
+        .validator
+        .unwrap()
+        .jailed_until
+        .is_some());
+
+    // An epoch passes and the validator gets to unjail themself
+    suite.advance_epoch().unwrap();
+    suite.unjail(members[1], members[1]).unwrap();
+
+    // Another epoch passes before the validator is added to the valset again
+    suite.advance_epoch().unwrap();
+    assert!(suite
+        .validator(members[1])
+        .unwrap()
+        .validator
+        .unwrap()
+        .jailed_until
+        .is_none());
+
+    // Validator should be PENDING after being re-added to the valset,
+    // so if they fail to sign a block to prove they're online, they get
+    // jailed -again-
+    suite.advance_epoch().unwrap();
+    assert!(suite
+        .validator(members[1])
+        .unwrap()
+        .validator
+        .unwrap()
+        .jailed_until
+        .is_some());
 }
 
 #[test]

--- a/contracts/tgrade-valset/src/multitest/verify_online.rs
+++ b/contracts/tgrade-valset/src/multitest/verify_online.rs
@@ -26,7 +26,7 @@ fn verify_validators_works() {
     let mut suite = SuiteBuilder::new()
         .with_operators(&members)
         .with_engagement(&members_init(&members, &[2, 3]))
-        .with_verify_validators()
+        .with_verify_validators(600)
         .build();
 
     suite
@@ -71,7 +71,7 @@ fn verify_validators_jailing() {
     let mut suite = SuiteBuilder::new()
         .with_operators(&members)
         .with_engagement(&members_init(&members, &[2, 3]))
-        .with_verify_validators()
+        .with_verify_validators(600)
         .build();
 
     suite
@@ -106,3 +106,4 @@ fn validator_needs_to_verify_if_unjailed() {
 #[ignore]
 fn validator_has_minimum_power_until_verified() {
     todo!()
+}

--- a/contracts/tgrade-valset/src/multitest/verify_online.rs
+++ b/contracts/tgrade-valset/src/multitest/verify_online.rs
@@ -1,0 +1,107 @@
+use std::convert::TryInto;
+
+use cosmwasm_std::Binary;
+use tg_bindings::{Ed25519Pubkey, ToAddress, ValidatorVote};
+
+use super::{
+    helpers::{addr_to_pubkey, members_init},
+    suite::SuiteBuilder,
+};
+
+fn addr_to_vote_addr(addr: &str) -> Binary {
+    let pubkey = addr_to_pubkey(addr);
+    let pubkey: Ed25519Pubkey = pubkey.try_into().unwrap();
+    Binary(pubkey.to_address().to_vec())
+}
+
+#[test]
+fn verify_validators_works() {
+    let members = vec![
+        "member1member1member1member1memb",
+        "member2member2member2member2memb",
+    ];
+
+    let mut suite = SuiteBuilder::new()
+        .with_operators(&members)
+        .with_engagement(&members_init(&members, &[2, 3]))
+        .with_verify_validators()
+        .build();
+
+    suite
+        .set_votes(&[
+            ValidatorVote {
+                address: addr_to_vote_addr(members[0]),
+                power: 2,
+                voted: true,
+            },
+            ValidatorVote {
+                address: addr_to_vote_addr(members[1]),
+                power: 3,
+                voted: true,
+            },
+        ])
+        .unwrap();
+
+    let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
+    let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
+    assert!(info1.jailed_until.is_none());
+    assert!(info2.jailed_until.is_none());
+    assert!(info1.active_validator);
+    assert!(info2.active_validator);
+
+    suite.next_block().unwrap();
+
+    let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
+    let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
+    assert!(info1.jailed_until.is_none());
+    assert!(info2.jailed_until.is_none());
+    assert!(info1.active_validator);
+    assert!(info2.active_validator);
+}
+
+#[test]
+fn verify_validators_jailing() {
+    let members = vec![
+        "member1member1member1member1memb",
+        "member2member2member2member2memb",
+    ];
+
+    let mut suite = SuiteBuilder::new()
+        .with_operators(&members)
+        .with_engagement(&members_init(&members, &[2, 3]))
+        .with_verify_validators()
+        .build();
+
+    suite
+        .set_votes(&[ValidatorVote {
+            address: addr_to_vote_addr(members[0]),
+            power: 2,
+            voted: true,
+        }])
+        .unwrap();
+
+    let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
+    let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
+    assert!(info1.jailed_until.is_none());
+    assert!(info2.jailed_until.is_none());
+
+    suite.next_block().unwrap();
+
+    let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
+    let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
+    assert!(info1.jailed_until.is_none());
+    assert!(info2.jailed_until.is_some());
+    // TODO: info2.active_validator is true - should it be true?
+}
+
+#[test]
+#[ignore]
+fn validator_needs_to_verify_if_unjailed() {
+    todo!();
+}
+
+#[test]
+#[ignore]
+fn validator_has_minimum_power_until_verified() {
+    todo!();
+}

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Addr, Coin, Decimal};
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, UniqueIndex};
 use tg4::Tg4Contract;
+use tg_utils::Duration;
 
 use crate::msg::{default_fee_percentage, JailingPeriod, ValidatorMetadata};
 use tg_bindings::{Ed25519Pubkey, Pubkey};
@@ -60,6 +61,10 @@ pub struct Config {
     /// The verification happens every time the validator becomes an active validator,
     /// including when they are unjailed or when they just gain enough power to participate.
     pub verify_validators: bool,
+
+    /// The duration to jail a validator for in case they don't sign their first epoch
+    /// boundary block. After the period, they have to pass verification again, ad infinitum.
+    pub offline_jail_duration: Duration,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -53,6 +53,13 @@ pub struct Config {
 
     /// Address of contract for validator group voting.
     pub validator_group: Addr,
+
+    /// When a validator joins the valset, verify they sign the first block since joining
+    /// or jail them for a period otherwise.
+    ///
+    /// The verification happens every time the validator becomes an active validator,
+    /// including when they are unjailed or when they just gain enough power to participate.
+    pub verify_validators: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -90,6 +97,10 @@ pub const EPOCH: Item<EpochInfo> = Item::new("epoch");
 /// VALIDATORS is the calculated list of the active validators from the last execution.
 /// This will be empty only on the first run.
 pub const VALIDATORS: Item<Vec<ValidatorInfo>> = Item::new("validators");
+
+/// A list of validators who have just became active and have yet to sign a block
+/// to verify they're online.
+pub const PENDING_VALIDATORS: Item<Vec<(Addr, Ed25519Pubkey)>> = Item::new("pending");
 
 /// Map of operator addr to block height it initially became a validator. If operator doesn't
 /// appear in this map, he was never in the validator set.


### PR DESCRIPTION
Closes #36

## Mechanism
At an epoch boundary, any newly added validators are marked as PENDING and their voting power is set to the minimum. Next epoch, these PENDING validators have to have signed the last block or they're jailed for a configurable period. If they do sign it, they get the full voting power.

## Work
- [x] Jailing mechanism
- [x] Voting power reduction thingy
- [x] Testing figured out
- [ ] Migration code

## Broken API
Two new fields in the instantiation msg:
```rust
    /// When a validator joins the valset, verify they sign the first block since joining
    /// or jail them for a period otherwise.
    ///
    /// The verification happens every time the validator becomes an active validator,
    /// including when they are unjailed or when they just gain enough power to participate.
    pub verify_validators: bool,

    /// The duration to jail a validator for in case they don't sign their first epoch
    /// boundary block. After the period, they have to pass verification again, ad infinitum.
    pub offline_jail_duration: Duration,
```

## Broken state
Two new fields in `CONFIG` - same as the instantiation msg.