### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,51 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0...HEAD)
-
-## [v0.7.0](https://github.com/confio/poe-contracts/tree/v0.7.0) (2022-03-28)
-
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2..v0.7.0)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2-patch1...HEAD)
 
 **Closed issues:**
 
 - grade-validator-voting: Operate on all contracts [\#119](https://github.com/confio/poe-contracts/issues/119)
-- Release 0.7.0-alpha1 [\#115](https://github.com/confio/poe-contracts/issues/115)
-- Update to cw-plus 0.12.1 [\#90](https://github.com/confio/poe-contracts/issues/90)
+- QA Steps to check breakages in CI [\#71](https://github.com/confio/poe-contracts/issues/71)
 
 **Merged pull requests:**
 
 - Stake vesting accounts [\#124](https://github.com/confio/poe-contracts/pull/124) ([maurolacy](https://github.com/maurolacy))
+
+## [v0.6.2-patch1](https://github.com/confio/poe-contracts/tree/v0.6.2-patch1) (2022-02-28)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0-alpha2...v0.6.2-patch1)
+
+## [v0.7.0-alpha2](https://github.com/confio/poe-contracts/tree/v0.7.0-alpha2) (2022-02-24)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0-alpha1...v0.7.0-alpha2)
+
+**Merged pull requests:**
+
 - Release 0.7.0-alpha2 [\#117](https://github.com/confio/poe-contracts/pull/117) ([ueco-jb](https://github.com/ueco-jb))
-- Release 0.7.0-alpha1 [\#116](https://github.com/confio/poe-contracts/pull/116) ([maurolacy](https://github.com/maurolacy))
-- Replace ballots with indexed map [\#114](https://github.com/confio/poe-contracts/pull/114) ([ueco-jb](https://github.com/ueco-jb))
-- Implement Querier for TgradeApp [\#111](https://github.com/confio/poe-contracts/pull/111) ([ethanfrey](https://github.com/ethanfrey))
-- Add description to tgrade-gov-reflect's Cargo.toml [\#107](https://github.com/confio/poe-contracts/pull/107) ([ueco-jb](https://github.com/ueco-jb))
-- Update to cw-plus 0.12.1 [\#103](https://github.com/confio/poe-contracts/pull/103) ([maurolacy](https://github.com/maurolacy))
+
+## [v0.7.0-alpha1](https://github.com/confio/poe-contracts/tree/v0.7.0-alpha1) (2022-02-23)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2...v0.7.0-alpha1)
 
 **Breaking changes:**
 
 - `JailingPeriod` - add information about start period [\#94](https://github.com/confio/poe-contracts/issues/94)
 - Refactor `BALLOTS` and `BALLOTS_BY_VOTER` in `voting-contract` [\#83](https://github.com/confio/poe-contracts/issues/83)
 - valset: store and expose the start of a jailing period [\#112](https://github.com/confio/poe-contracts/pull/112) ([uint](https://github.com/uint))
+
+**Closed issues:**
+
+- Release 0.7.0-alpha1 [\#115](https://github.com/confio/poe-contracts/issues/115)
+- Update to cw-plus 0.12.1 [\#90](https://github.com/confio/poe-contracts/issues/90)
+
+**Merged pull requests:**
+
+- Release 0.7.0-alpha1 [\#116](https://github.com/confio/poe-contracts/pull/116) ([maurolacy](https://github.com/maurolacy))
+- Replace ballots with indexed map [\#114](https://github.com/confio/poe-contracts/pull/114) ([ueco-jb](https://github.com/ueco-jb))
+- Implement Querier for TgradeApp [\#111](https://github.com/confio/poe-contracts/pull/111) ([ethanfrey](https://github.com/ethanfrey))
+- Add description to tgrade-gov-reflect's Cargo.toml [\#107](https://github.com/confio/poe-contracts/pull/107) ([ueco-jb](https://github.com/ueco-jb))
+- Update to cw-plus 0.12.1 [\#103](https://github.com/confio/poe-contracts/pull/103) ([maurolacy](https://github.com/maurolacy))
 
 ## [v0.6.2](https://github.com/confio/poe-contracts/tree/v0.6.2) (2022-02-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,33 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0-alpha2...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0...HEAD)
 
-## [v0.7.0](https://github.com/confio/poe-contracts/tree/v0.7.0-alpha2) (2022-02-22)
+## [v0.7.0](https://github.com/confio/poe-contracts/tree/v0.7.0) (2022-03-28)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2...v0.7.0-alpha2)
-
-**Breaking changes:**
-
-- Refactor `BALLOTS` and `BALLOTS_BY_VOTER` in `voting-contract` [\#83](https://github.com/confio/poe-contracts/pull/83) ([ueco-jb](https://github.com/ueco-jb))
-- `JailingPeriod` - add information about start period [\#94](https://github.com/confio/poe-contracts/issues/94)
-- valset: store and expose the start of a jailing period [\#112](https://github.com/confio/poe-contracts/pull/112) ([uint](https://github.com/uint))
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2..v0.7.0)
 
 **Closed issues:**
 
+- grade-validator-voting: Operate on all contracts [\#119](https://github.com/confio/poe-contracts/issues/119)
+- Release 0.7.0-alpha1 [\#115](https://github.com/confio/poe-contracts/issues/115)
 - Update to cw-plus 0.12.1 [\#90](https://github.com/confio/poe-contracts/issues/90)
 
 **Merged pull requests:**
 
+- Stake vesting accounts [\#124](https://github.com/confio/poe-contracts/pull/124) ([maurolacy](https://github.com/maurolacy))
+- Release 0.7.0-alpha2 [\#117](https://github.com/confio/poe-contracts/pull/117) ([ueco-jb](https://github.com/ueco-jb))
+- Release 0.7.0-alpha1 [\#116](https://github.com/confio/poe-contracts/pull/116) ([maurolacy](https://github.com/maurolacy))
 - Replace ballots with indexed map [\#114](https://github.com/confio/poe-contracts/pull/114) ([ueco-jb](https://github.com/ueco-jb))
 - Implement Querier for TgradeApp [\#111](https://github.com/confio/poe-contracts/pull/111) ([ethanfrey](https://github.com/ethanfrey))
 - Add description to tgrade-gov-reflect's Cargo.toml [\#107](https://github.com/confio/poe-contracts/pull/107) ([ueco-jb](https://github.com/ueco-jb))
 - Update to cw-plus 0.12.1 [\#103](https://github.com/confio/poe-contracts/pull/103) ([maurolacy](https://github.com/maurolacy))
+
+**Breaking changes:**
+
+- `JailingPeriod` - add information about start period [\#94](https://github.com/confio/poe-contracts/issues/94)
+- Refactor `BALLOTS` and `BALLOTS_BY_VOTER` in `voting-contract` [\#83](https://github.com/confio/poe-contracts/issues/83)
+- valset: store and expose the start of a jailing period [\#112](https://github.com/confio/poe-contracts/pull/112) ([uint](https://github.com/uint))
 
 ## [v0.6.2](https://github.com/confio/poe-contracts/tree/v0.6.2) (2022-02-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,51 +2,34 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2-patch1...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0...HEAD)
+
+## [v0.7.0](https://github.com/confio/poe-contracts/tree/v0.7.0) (2022-03-28)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2...v0.7.0)
 
 **Closed issues:**
 
 - grade-validator-voting: Operate on all contracts [\#119](https://github.com/confio/poe-contracts/issues/119)
 - QA Steps to check breakages in CI [\#71](https://github.com/confio/poe-contracts/issues/71)
+- Release 0.7.0-alpha1 [\#115](https://github.com/confio/poe-contracts/issues/115)
+- Update to cw-plus 0.12.1 [\#90](https://github.com/confio/poe-contracts/issues/90)
 
 **Merged pull requests:**
 
 - Stake vesting accounts [\#124](https://github.com/confio/poe-contracts/pull/124) ([maurolacy](https://github.com/maurolacy))
-
-## [v0.6.2-patch1](https://github.com/confio/poe-contracts/tree/v0.6.2-patch1) (2022-02-28)
-
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0-alpha2...v0.6.2-patch1)
-
-## [v0.7.0-alpha2](https://github.com/confio/poe-contracts/tree/v0.7.0-alpha2) (2022-02-24)
-
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0-alpha1...v0.7.0-alpha2)
-
-**Merged pull requests:**
-
 - Release 0.7.0-alpha2 [\#117](https://github.com/confio/poe-contracts/pull/117) ([ueco-jb](https://github.com/ueco-jb))
-
-## [v0.7.0-alpha1](https://github.com/confio/poe-contracts/tree/v0.7.0-alpha1) (2022-02-23)
-
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2...v0.7.0-alpha1)
+- Release 0.7.0-alpha1 [\#116](https://github.com/confio/poe-contracts/pull/116) ([maurolacy](https://github.com/maurolacy))
+- Replace ballots with indexed map [\#114](https://github.com/confio/poe-contracts/pull/114) ([ueco-jb](https://github.com/ueco-jb))
+- Implement Querier for TgradeApp [\#111](https://github.com/confio/poe-contracts/pull/111) ([ethanfrey](https://github.com/ethanfrey))
+- Add description to tgrade-gov-reflect's Cargo.toml [\#107](https://github.com/confio/poe-contracts/pull/107) ([ueco-jb](https://github.com/ueco-jb))
+- Update to cw-plus 0.12.1 [\#103](https://github.com/confio/poe-contracts/pull/103) ([maurolacy](https://github.com/maurolacy))
 
 **Breaking changes:**
 
 - `JailingPeriod` - add information about start period [\#94](https://github.com/confio/poe-contracts/issues/94)
 - Refactor `BALLOTS` and `BALLOTS_BY_VOTER` in `voting-contract` [\#83](https://github.com/confio/poe-contracts/issues/83)
 - valset: store and expose the start of a jailing period [\#112](https://github.com/confio/poe-contracts/pull/112) ([uint](https://github.com/uint))
-
-**Closed issues:**
-
-- Release 0.7.0-alpha1 [\#115](https://github.com/confio/poe-contracts/issues/115)
-- Update to cw-plus 0.12.1 [\#90](https://github.com/confio/poe-contracts/issues/90)
-
-**Merged pull requests:**
-
-- Release 0.7.0-alpha1 [\#116](https://github.com/confio/poe-contracts/pull/116) ([maurolacy](https://github.com/maurolacy))
-- Replace ballots with indexed map [\#114](https://github.com/confio/poe-contracts/pull/114) ([ueco-jb](https://github.com/ueco-jb))
-- Implement Querier for TgradeApp [\#111](https://github.com/confio/poe-contracts/pull/111) ([ethanfrey](https://github.com/ethanfrey))
-- Add description to tgrade-gov-reflect's Cargo.toml [\#107](https://github.com/confio/poe-contracts/pull/107) ([ueco-jb](https://github.com/ueco-jb))
-- Update to cw-plus 0.12.1 [\#103](https://github.com/confio/poe-contracts/pull/103) ([maurolacy](https://github.com/maurolacy))
 
 ## [v0.6.2](https://github.com/confio/poe-contracts/tree/v0.6.2) (2022-02-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 [Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0...HEAD)
 
-## [v0.7.0](https://github.com/confio/poe-contracts/tree/v0.7.0) (2022-03-28)
+## [v0.8.0](https://github.com/confio/poe-contracts/tree/v0.8.0) (2022-03-29)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2...v0.7.0)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.6.2...v0.8.0)
 
 **Closed issues:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "tg3"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "tg3"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.7.0-alpha2" }
-tg-utils = { version = "0.7.0-alpha2", path = "../../packages/utils" }
-tg-bindings = { version = "0.7.0-alpha2", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.7.0" }
+tg-utils = { version = "0.7.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = { version = "0.13.1" }
-tg-bindings-test = { version = "0.7.0-alpha2", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.7.0" }
-tg-utils = { version = "0.7.0", path = "../../packages/utils" }
-tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.8.0" }
+tg-utils = { version = "0.8.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = { version = "0.13.1" }
-tg-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-group"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Mauro Lacy <mauro@confio.gmbh>"]
 edition = "2018"
 description = "Simple tg4 implementation of group membership controlled by admin"
@@ -29,7 +29,7 @@ library = []
 cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw4 = "0.13.1"
-tg4 = { version = "0.7.0-alpha2", path = "../../packages/tg4" }
+tg4 = { version = "0.7.0", path = "../../packages/tg4" }
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
 cosmwasm-std = { version = "1.0.0-beta6" }

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-group"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Mauro Lacy <mauro@confio.gmbh>"]
 edition = "2018"
 description = "Simple tg4 implementation of group membership controlled by admin"
@@ -29,7 +29,7 @@ library = []
 cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw4 = "0.13.1"
-tg4 = { version = "0.7.0", path = "../../packages/tg4" }
+tg4 = { version = "0.8.0", path = "../../packages/tg4" }
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
 cosmwasm-std = { version = "1.0.0-beta6" }

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw20 = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.7.0" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
+tg4 = { path = "../../packages/tg4", version = "0.8.0" }
+tg-utils = { path = "../../packages/utils", version = "0.8.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
 cosmwasm-std = "1.0.0-beta6"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -44,8 +44,8 @@ cosmwasm-vm = { version = "1.0.0-beta6", optional = true }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = { version = "0.13.1" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.7.0", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.0", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.8.0", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw20 = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.7.0-alpha2" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0-alpha2" }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0-alpha2" }
+tg4 = { path = "../../packages/tg4", version = "0.7.0" }
+tg-utils = { path = "../../packages/utils", version = "0.7.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
 cosmwasm-std = "1.0.0-beta6"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -44,8 +44,8 @@ cosmwasm-vm = { version = "1.0.0-beta6", optional = true }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = { version = "0.13.1" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0-alpha2", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.7.0-alpha2", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.7.0", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.7.0", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.7.0-alpha2" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0-alpha2" }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0-alpha2" }
+tg4 = { path = "../../packages/tg4", version = "0.7.0" }
+tg-utils = { path = "../../packages/utils", version = "0.7.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,4 +35,4 @@ itertools = "0.10"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0-alpha2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.7.0" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
+tg4 = { path = "../../packages/tg4", version = "0.8.0" }
+tg-utils = { path = "../../packages/utils", version = "0.8.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,4 +35,4 @@ itertools = "0.10"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -18,19 +18,19 @@ library = []
 
 [dependencies]
 cw2 = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.7.0-alpha2" }
+tg3 = { path = "../../packages/tg3", version = "0.7.0" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0-alpha2" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0-alpha2" }
-tg-voting-contract = { version = "0.7.0-alpha2", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0-alpha2", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
+tg-utils = { path = "../../packages/utils", version = "0.7.0" }
+tg-voting-contract = { version = "0.7.0", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.7.0", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0-alpha2" }
-tg4 = { path = "../../packages/tg4", version = "0.7.0-alpha2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
+tg4 = { path = "../../packages/tg4", version = "0.7.0" }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -18,19 +18,19 @@ library = []
 
 [dependencies]
 cw2 = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.7.0" }
+tg3 = { path = "../../packages/tg3", version = "0.8.0" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0" }
-tg-voting-contract = { version = "0.7.0", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
+tg-utils = { path = "../../packages/utils", version = "0.8.0" }
+tg-voting-contract = { version = "0.8.0", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.0", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
-tg4 = { path = "../../packages/tg4", version = "0.7.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
+tg4 = { path = "../../packages/tg4", version = "0.8.0" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-gov-reflect voting contract"
@@ -26,7 +26,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta6"
 cw-storage-plus = "0.13.1"
-tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-gov-reflect voting contract"
@@ -26,7 +26,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta6"
 cw-storage-plus = "0.13.1"
-tg-bindings = { version = "0.7.0-alpha2", path = "../../packages/bindings" }
+tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -18,13 +18,13 @@ library = []
 
 [dependencies]
 cw2 = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.7.0" }
+tg3 = { path = "../../packages/tg3", version = "0.8.0" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0" }
-tg-voting-contract = { version = "0.7.0", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
+tg-utils = { path = "../../packages/utils", version = "0.8.0" }
+tg-voting-contract = { version = "0.8.0", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.7.0", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.7.0", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.7.0" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0", features = ["library"] }
+tg-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.8.0", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.8.0", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.8.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.0", features = ["library"] }

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -18,13 +18,13 @@ library = []
 
 [dependencies]
 cw2 = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.7.0-alpha2" }
+tg3 = { path = "../../packages/tg3", version = "0.7.0" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.7.0-alpha2" }
-tg-utils = { path = "../../packages/utils", version = "0.7.0-alpha2" }
-tg-voting-contract = { version = "0.7.0-alpha2", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.7.0" }
+tg-utils = { path = "../../packages/utils", version = "0.7.0" }
+tg-voting-contract = { version = "0.7.0", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg-bindings-test = { version = "0.7.0-alpha2", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.7.0-alpha2", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.7.0-alpha2", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.7.0-alpha2" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0-alpha2", features = ["library"] }
+tg-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.7.0", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.7.0", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.7.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.7.0", features = ["library"] }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -36,9 +36,9 @@ schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
-tg4 = { path = "../../packages/tg4", version = "0.7.0" }
-tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.7.0", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.8.0" }
+tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.8.0", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
@@ -47,10 +47,10 @@ cosmwasm-vm = { version = "1.0.0-beta6", optional = true, default-features = fal
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = "0.13.1"
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0" }
-tg4-stake = { path = "../tg4-stake", version = "0.7.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.0" }
+tg4-stake = { path = "../tg4-stake", version = "0.8.0" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -36,9 +36,9 @@ schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
-tg4 = { path = "../../packages/tg4", version = "0.7.0-alpha2" }
-tg-bindings = { version = "0.7.0-alpha2", path = "../../packages/bindings" }
-tg-utils = { version = "0.7.0-alpha2", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.7.0" }
+tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.7.0", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
@@ -47,10 +47,10 @@ cosmwasm-vm = { version = "1.0.0-beta6", optional = true, default-features = fal
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = "0.13.1"
-tg4-engagement = { path = "../tg4-engagement", version = "0.7.0-alpha2" }
-tg4-stake = { path = "../tg4-stake", version = "0.7.0-alpha2" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.7.0" }
+tg4-stake = { path = "../tg4-stake", version = "0.7.0" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0-alpha2" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.13.1"
 cw-storage-plus = "0.13.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.7.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.8.0", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
-tg-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.13.1"
 cw-storage-plus = "0.13.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.7.0-alpha2", path = "../../packages/bindings" }
-tg-utils = { version = "0.7.0-alpha2", path = "../../packages/utils" }
+tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.7.0", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
-tg-bindings-test = { version = "0.7.0-alpha2", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.7.0", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.7.0", path = "../bindings" }
+tg-bindings = { version = "0.8.0", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.7.0-alpha2", path = "../bindings" }
+tg-bindings = { version = "0.7.0", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta6"
-tg-voting-contract = { path = "../voting-contract", version = "0.7.0" }
+tg-voting-contract = { path = "../voting-contract", version = "0.8.0" }

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta6"
-tg-voting-contract = { path = "../voting-contract", version = "0.7.0-alpha2" }
+tg-voting-contract = { path = "../voting-contract", version = "0.7.0" }

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg3"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Tgrade-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.7.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.8.0", path = "../../packages/utils" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0-beta6"

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg3"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Tgrade-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.7.0-alpha2", path = "../../packages/bindings" }
-tg-utils = { version = "0.7.0-alpha2", path = "../../packages/utils" }
+tg-bindings = { version = "0.7.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.7.0", path = "../../packages/utils" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0-beta6"

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.7.0" }
+tg-bindings = { path = "../bindings", version = "0.8.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.7.0-alpha2" }
+tg-bindings = { path = "../bindings", version = "0.7.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.13.1"
 cw2 = "0.13.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.7.0" }
-tg-bindings = { path = "../bindings", version = "0.7.0" }
+tg4 = { path = "../tg4", version = "0.8.0" }
+tg-bindings = { path = "../bindings", version = "0.8.0" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.13.1"
 cw2 = "0.13.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.7.0-alpha2" }
-tg-bindings = { path = "../bindings", version = "0.7.0-alpha2" }
+tg4 = { path = "../tg4", version = "0.7.0" }
+tg-bindings = { path = "../bindings", version = "0.7.0" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -12,14 +12,14 @@ license = "Apache-2.0"
 
 [dependencies]
 cw-utils = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.7.0" }
+tg3 = { path = "../../packages/tg3", version = "0.8.0" }
 cw-storage-plus = "0.13.1"
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.7.0" }
-tg-bindings = { path = "../bindings", version = "0.7.0" }
-tg-utils = { version = "0.7.0", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.8.0" }
+tg-bindings = { path = "../bindings", version = "0.8.0" }
+tg-utils = { version = "0.8.0", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.7.0", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.8.0", features = ["library"] }

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.7.0-alpha2"
+version = "0.7.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -12,14 +12,14 @@ license = "Apache-2.0"
 
 [dependencies]
 cw-utils = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.7.0-alpha2" }
+tg3 = { path = "../../packages/tg3", version = "0.7.0" }
 cw-storage-plus = "0.13.1"
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.7.0-alpha2" }
-tg-bindings = { path = "../bindings", version = "0.7.0-alpha2" }
-tg-utils = { version = "0.7.0-alpha2", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.7.0" }
+tg-bindings = { path = "../bindings", version = "0.7.0" }
+tg-utils = { version = "0.7.0", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0-alpha2" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.7.0-alpha2", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.7.0" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.7.0", features = ["library"] }

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -4,8 +4,7 @@ command -v shellcheck >/dev/null && shellcheck "$0"
 
 function print_usage() {
   echo "Usage: $0 NEW_VERSION"
-  echo ""
-  echo "e.g. $0 0.5.0"
+  echo "E.g.: $0 0.5.0"
 }
 
 if [ "$#" -ne 1 ]; then
@@ -21,7 +20,7 @@ if [[ "$(realpath "$SCRIPT_DIR/..")" != "$(pwd)" ]]; then
 fi
 
 # Ensure repo is not dirty
-CHANGES_IN_REPO=$(git status --porcelain)
+CHANGES_IN_REPO=$(git status --porcelain --untracked-files=no)
 if [[ -n "$CHANGES_IN_REPO" ]]; then
     echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
     git status && git --no-pager diff

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
+set -o errexit -o pipefail
 
 ORIGINAL_OPTS=$*
-OPTS=$(getopt -l "help,since-tag:,full,token:" -o "hft" -- "$@") || exit 1
+OPTS=$(getopt -l "help,since-tag:,upcoming-tag:,full,token:" -o "hu:ft" -- "$@") || exit 1
+
+function print_usage() {
+    echo -e "Usage: $0 [-h|--help] [-f|--full] [--since-tag <tag>] [-u|--upcoming-tag] <tag> [-t|--token <token>]
+-h, --help               Display help
+-f, --full               Process changes since the beginning (by default: since latest git version tag)
+--since-tag <tag>        Process changes since git version tag <tag> (by default: since latest git version tag)
+-u, --upcoming-tag <tag> Add a <tag> title in CHANGELOG for the new changes
+--token <token>          Pass changelog github token <token>"
+}
+
+function remove_opt() {
+    ORIGINAL_OPTS=$(echo "$ORIGINAL_OPTS" | sed "s/\\B$1\\b//")
+}
 
 eval set -- "$OPTS"
 while true
 do
 case $1 in
   -h|--help)
-    echo -e "Usage: $0 [-h|--help] [-f|--full] [--since-tag <tag>] [-t|--token <token>]
--h, --help          Display help
--f, --full          Process changes since the beginning (by default: since latest git version tag)
---since-tag <tag>   Process changes since git version tag <tag> (by default: since latest git version tag)
---token <token>     Pass changelog github token <token>"
+    print_usage
     exit 0
     ;;
   --since-tag)
@@ -21,7 +31,13 @@ case $1 in
     ;;
   -f|--full)
     TAG="<FULL>"
-    ORIGINAL_OPTS=$(echo "$ORIGINAL_OPTS" | sed "s/\\B$1\\b//")
+    remove_opt $1
+    ;;
+  -u|--upcoming-tag)
+    remove_opt $1
+    shift
+    UPCOMING_TAG="$1"
+    remove_opt $1
     ;;
   --)
     shift
@@ -48,5 +64,12 @@ echo "Consolidated tag: $TAG"
 sed -i -n "/^## \\[${TAG}[^]]*\\]/,\$p" CHANGELOG.md
 
 github_changelog_generator -u confio -p poe-contracts --base CHANGELOG.md $ORIGINAL_OPTS || cp /tmp/CHANGELOG.md.$$ CHANGELOG.md
+
+if [ -n "$UPCOMING_TAG" ]
+then
+  # Add "upcoming" version tag
+  TODAY=$(date "+%Y-%m-%d")
+  sed -i "s+\[Full Changelog\](https://github.com/CosmWasm/cw-plus/compare/\(.*\)\.\.\.HEAD)+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/$UPCOMING_TAG...HEAD)\n\n## [$UPCOMING_TAG](https://github.com/CosmWasm/cw-plus/tree/$UPCOMING_TAG) ($TODAY)\n\n[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/\1...$UPCOMING_TAG)+" CHANGELOG.md
+fi
 
 rm -f /tmp/CHANGELOG.md.$$

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -2,6 +2,7 @@
 set -o errexit -o pipefail
 
 ORIGINAL_OPTS=$*
+# Requires getopt from util-linux 2.37.4 (brew install gnu-getopt on Mac)
 OPTS=$(getopt -l "help,since-tag:,upcoming-tag:,full,token:" -o "hu:ft" -- "$@") || exit 1
 
 function print_usage() {

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -o errexit -o pipefail
 
+# Customize these
+# TODO: Get it from ./.git/config
+GITHUB_USER="confio"
+GITHUB_REPO="poe-contracts"
+
 ORIGINAL_OPTS=$*
 # Requires getopt from util-linux 2.37.4 (brew install gnu-getopt on Mac)
 OPTS=$(getopt -l "help,since-tag:,upcoming-tag:,full,token:" -o "hu:ft" -- "$@") || exit 1
@@ -64,13 +69,13 @@ TAG=$(echo "$TAG" | sed -e 's/-\([A-Za-z]*\)[^A-Za-z]*/-\1/' -e 's/-$//')
 echo "Consolidated tag: $TAG"
 sed -i -n "/^## \\[${TAG}[^]]*\\]/,\$p" CHANGELOG.md
 
-github_changelog_generator -u confio -p poe-contracts --base CHANGELOG.md $ORIGINAL_OPTS || cp /tmp/CHANGELOG.md.$$ CHANGELOG.md
+github_changelog_generator -u $GITHUB_USER -p $GITHUB_REPO --base CHANGELOG.md $ORIGINAL_OPTS || cp /tmp/CHANGELOG.md.$$ CHANGELOG.md
 
 if [ -n "$UPCOMING_TAG" ]
 then
   # Add "upcoming" version tag
   TODAY=$(date "+%Y-%m-%d")
-  sed -i "s+\[Full Changelog\](https://github.com/CosmWasm/cw-plus/compare/\(.*\)\.\.\.HEAD)+[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/$UPCOMING_TAG...HEAD)\n\n## [$UPCOMING_TAG](https://github.com/CosmWasm/cw-plus/tree/$UPCOMING_TAG) ($TODAY)\n\n[Full Changelog](https://github.com/CosmWasm/cw-plus/compare/\1...$UPCOMING_TAG)+" CHANGELOG.md
+  sed -i "s+\[Full Changelog\](https://github.com/$GITHUB_USER/$GITHUB_REPO/compare/\(.*\)\.\.\.HEAD)+[Full Changelog](https://github.com/$GITHUB_USER/$GITHUB_REPO/compare/$UPCOMING_TAG...HEAD)\n\n## [$UPCOMING_TAG](https://github.com/$GITHUB_USER/$GITHUB_REPO/tree/$UPCOMING_TAG) ($TODAY)\n\n[Full Changelog](https://github.com/$GITHUB_USER/$GITHUB_REPO/compare/\1...$UPCOMING_TAG)+" CHANGELOG.md
 fi
 
 rm -f /tmp/CHANGELOG.md.$$


### PR DESCRIPTION
v0.8.0 release. To be used for upcoming internal-10 and dryrunnet testnets.

Just synched `update_changelog.sh` with the version in cw-plus in passing.

Added notice about required `getopt` version for Mac.