### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.7.0...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.8.1...HEAD)
+
+## [v0.8.1](https://github.com/confio/poe-contracts/tree/v0.8.1) (2022-03-29)
+
+Maintenance release. Wrong tgrade-valset version published to crates-io.
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.8.0...v0.8.1)
 
 ## [v0.8.0](https://github.com/confio/poe-contracts/tree/v0.8.0) (2022-03-29)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "tg3"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -24,9 +24,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.8.0" }
-tg-utils = { version = "0.8.0", path = "../../packages/utils" }
-tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.8.1" }
+tg-utils = { version = "0.8.1", path = "../../packages/utils" }
+tg-bindings = { version = "0.8.1", path = "../../packages/bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,6 +35,6 @@ thiserror = { version = "1.0.21" }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = { version = "0.13.1" }
-tg-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.8.1", path = "../../packages/bindings-test" }
 derivative = "2"
 anyhow = "1"

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-group"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Mauro Lacy <mauro@confio.gmbh>"]
 edition = "2018"
 description = "Simple tg4 implementation of group membership controlled by admin"
@@ -29,7 +29,7 @@ library = []
 cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw4 = "0.13.1"
-tg4 = { version = "0.8.0", path = "../../packages/tg4" }
+tg4 = { version = "0.8.1", path = "../../packages/tg4" }
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
 cosmwasm-std = { version = "1.0.0-beta6" }

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -27,9 +27,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw20 = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.8.0" }
-tg-utils = { path = "../../packages/utils", version = "0.8.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
+tg4 = { path = "../../packages/tg4", version = "0.8.1" }
+tg-utils = { path = "../../packages/utils", version = "0.8.1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.1" }
 cosmwasm-std = "1.0.0-beta6"
 integer-sqrt = "0.1.5"
 schemars = "0.8"
@@ -44,8 +44,8 @@ cosmwasm-vm = { version = "1.0.0-beta6", optional = true }
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = { version = "0.13.1" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.8.0", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.8.0", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.1", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.8.1", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -24,9 +24,9 @@ cw-utils = "0.13.1"
 cw2 = "0.13.1"
 cw-controllers = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg4 = { path = "../../packages/tg4", version = "0.8.0" }
-tg-utils = { path = "../../packages/utils", version = "0.8.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
+tg4 = { path = "../../packages/tg4", version = "0.8.1" }
+tg-utils = { path = "../../packages/utils", version = "0.8.1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.1" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -35,4 +35,4 @@ itertools = "0.10"
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.1" }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -18,19 +18,19 @@ library = []
 
 [dependencies]
 cw2 = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.8.0" }
+tg3 = { path = "../../packages/tg3", version = "0.8.1" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
-tg-utils = { path = "../../packages/utils", version = "0.8.0" }
-tg-voting-contract = { version = "0.8.0", path = "../../packages/voting-contract" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.8.0", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.1" }
+tg-utils = { path = "../../packages/utils", version = "0.8.1" }
+tg-voting-contract = { version = "0.8.1", path = "../../packages/voting-contract" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.1", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
-tg4 = { path = "../../packages/tg4", version = "0.8.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.1" }
+tg4 = { path = "../../packages/tg4", version = "0.8.1" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-gov-reflect voting contract"
@@ -26,7 +26,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 [dependencies]
 cosmwasm-std = "1.0.0-beta6"
 cw-storage-plus = "0.13.1"
-tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
+tg-bindings = { version = "0.8.1", path = "../../packages/bindings" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1"

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -18,13 +18,13 @@ library = []
 
 [dependencies]
 cw2 = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.8.0" }
+tg3 = { path = "../../packages/tg3", version = "0.8.1" }
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.8.0" }
-tg-utils = { path = "../../packages/utils", version = "0.8.0" }
-tg-voting-contract = { version = "0.8.0", path = "../../packages/voting-contract" }
+tg-bindings = { path = "../../packages/bindings", version = "0.8.1" }
+tg-utils = { path = "../../packages/utils", version = "0.8.1" }
+tg-voting-contract = { version = "0.8.1", path = "../../packages/voting-contract" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,8 +32,8 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
 cw-storage-plus = "0.13.1"
-tg-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.8.0", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.8.0", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.8.0" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.8.0", features = ["library"] }
+tg-bindings-test = { version = "0.8.1", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.8.1", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.8.1", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.8.1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.1", features = ["library"] }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -36,9 +36,9 @@ schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.21" }
-tg4 = { path = "../../packages/tg4", version = "0.8.0" }
-tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.8.0", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.8.1" }
+tg-bindings = { version = "0.8.1", path = "../../packages/bindings" }
+tg-utils = { version = "0.8.1", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
@@ -47,10 +47,10 @@ cosmwasm-vm = { version = "1.0.0-beta6", optional = true, default-features = fal
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = "0.13.1"
-tg4-engagement = { path = "../tg4-engagement", version = "0.8.0" }
-tg4-stake = { path = "../tg4-stake", version = "0.8.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.8.1" }
+tg4-stake = { path = "../tg4-stake", version = "0.8.1" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.1" }
 derivative = "2"
 anyhow = "1"
 assert_matches = "1.5"

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.13.1"
 cw-storage-plus = "0.13.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.8.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.8.1", path = "../../packages/bindings" }
+tg-utils = { version = "0.8.1", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
-tg-bindings-test = { version = "0.8.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.8.1", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -9,7 +9,7 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-tg-bindings = { version = "0.8.0", path = "../bindings" }
+tg-bindings = { version = "0.8.1", path = "../bindings" }
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.0.0-beta6"
-tg-voting-contract = { path = "../voting-contract", version = "0.8.0" }
+tg-voting-contract = { path = "../voting-contract", version = "0.8.1" }

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg3"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Tgrade-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.8.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.8.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.8.1", path = "../../packages/bindings" }
+tg-utils = { version = "0.8.1", path = "../../packages/utils" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0-beta6"

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = { version = "1.0.0-beta6" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.8.0" }
+tg-bindings = { path = "../bindings", version = "0.8.1" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0-beta6" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -18,7 +18,7 @@ cw-storage-plus = "0.13.1"
 cw2 = "0.13.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.8.0" }
-tg-bindings = { path = "../bindings", version = "0.8.0" }
+tg4 = { path = "../tg4", version = "0.8.1" }
+tg-bindings = { path = "../bindings", version = "0.8.1" }
 thiserror = { version = "1.0.21" }
 semver = "1"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -12,14 +12,14 @@ license = "Apache-2.0"
 
 [dependencies]
 cw-utils = "0.13.1"
-tg3 = { path = "../../packages/tg3", version = "0.8.0" }
+tg3 = { path = "../../packages/tg3", version = "0.8.1" }
 cw-storage-plus = "0.13.1"
 cosmwasm-std = "1.0.0-beta6"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.8.0" }
-tg-bindings = { path = "../bindings", version = "0.8.0" }
-tg-utils = { version = "0.8.0", path = "../utils" }
+tg4 = { path = "../tg4", version = "0.8.1" }
+tg-bindings = { path = "../bindings", version = "0.8.1" }
+tg-utils = { version = "0.8.1", path = "../utils" }
 thiserror = { version = "1" }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.1"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.0" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.8.0", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.8.1" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.8.1", features = ["library"] }


### PR DESCRIPTION
Just for tagging and re-publishing to crates-io. `tgrade-valset` v0.8.0 is the wrong version, and shouldn't be used.