### PR TITLE
Rename rewards to points in mixer

### DIFF
--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -19,14 +19,14 @@ const DESERIALIZATION_LIMIT: usize = 20_000;
 const GAS_MULTIPLIER: u64 = 140_000_000;
 
 fn main() {
-    const MAX_REWARDS: u64 = 1000;
+    const MAX_POINTS: u64 = 1000;
 
     const STAKE: u64 = 100000;
     const ENGAGEMENT: u64 = 5000;
 
     let mut deps = mock_instance(WASM, &[]);
 
-    let max_rewards = Uint64::new(MAX_REWARDS);
+    let max_points = Uint64::new(MAX_POINTS);
     let a = Decimal::from_ratio(37u128, 10u128);
     let p = Decimal::from_ratio(68u128, 100u128);
     let s = Decimal::from_ratio(3u128, 100000u128);
@@ -37,14 +37,14 @@ fn main() {
         ("GeometricMean", GeometricMean {}, 22360, 5893350000),
         (
             "Sigmoid",
-            Sigmoid { max_rewards, p, s },
-            MAX_REWARDS,
+            Sigmoid { max_points, p, s },
+            MAX_POINTS,
             91848300000,
         ),
         (
             "SigmoidSqrt",
             SigmoidSqrt {
-                max_rewards,
+                max_points,
                 s: s_sqrt,
             },
             997,
@@ -53,7 +53,7 @@ fn main() {
         (
             "AlgebraicSigmoid",
             AlgebraicSigmoid {
-                max_rewards,
+                max_points,
                 a,
                 p,
                 s,

--- a/contracts/tg4-mixer/src/contract.rs
+++ b/contracts/tg4-mixer/src/contract.rs
@@ -391,9 +391,9 @@ pub fn query(deps: Deps<TgradeQuery>, _env: Env, msg: QueryMsg) -> StdResult<Bin
             engagement,
             poe_function,
         } => {
-            let reward = query_mixer_function(deps, stake.u64(), engagement.u64(), poe_function)
+            let points = query_mixer_function(deps, stake.u64(), engagement.u64(), poe_function)
                 .map_err(|err| StdError::generic_err(err.to_string()))?;
-            to_binary(&MixerFunctionResponse { points: reward })
+            to_binary(&MixerFunctionResponse { points })
         }
         IsSlasher { addr } => {
             let addr = deps.api.addr_validate(&addr)?;

--- a/contracts/tg4-mixer/src/msg.rs
+++ b/contracts/tg4-mixer/src/msg.rs
@@ -29,9 +29,9 @@ pub enum PoEFunctionType {
     /// GeometricMean returns the geometric mean of staked amount and engagement points
     GeometricMean {},
     /// Sigmoid returns a sigmoid-like value of staked amount times engagement points.
-    /// See the Proof-of-Engagement whitepaper for details
+    /// See the Proof-of-Engagement white-paper for details.
     Sigmoid {
-        max_rewards: Uint64,
+        max_points: Uint64,
         p: StdDecimal,
         s: StdDecimal,
     },
@@ -39,11 +39,11 @@ pub enum PoEFunctionType {
     /// engagement points.
     /// It is equal to `Sigmoid` with `p = 0.5`, but implemented using integer sqrt instead of
     /// fixed-point fractional power.
-    SigmoidSqrt { max_rewards: Uint64, s: StdDecimal },
+    SigmoidSqrt { max_points: Uint64, s: StdDecimal },
     /// `AlgebraicSigmoid` returns a sigmoid-like value of staked amount times engagement points.
     /// It is similar to `Sigmoid`, but uses integer sqrt instead of a fixed-point exponential.
     AlgebraicSigmoid {
-        max_rewards: Uint64,
+        max_points: Uint64,
         a: StdDecimal,
         p: StdDecimal,
         s: StdDecimal,
@@ -54,18 +54,18 @@ impl PoEFunctionType {
     pub fn to_poe_fn(&self) -> Result<Box<dyn PoEFunction>, ContractError> {
         match self.clone() {
             PoEFunctionType::GeometricMean {} => Ok(Box::new(GeometricMean::new())),
-            PoEFunctionType::Sigmoid { max_rewards, p, s } => {
-                Ok(Box::new(Sigmoid::new(max_rewards, p, s)?))
+            PoEFunctionType::Sigmoid { max_points, p, s } => {
+                Ok(Box::new(Sigmoid::new(max_points, p, s)?))
             }
-            PoEFunctionType::SigmoidSqrt { max_rewards, s } => {
-                Ok(Box::new(SigmoidSqrt::new(max_rewards, s)?))
+            PoEFunctionType::SigmoidSqrt { max_points, s } => {
+                Ok(Box::new(SigmoidSqrt::new(max_points, s)?))
             }
             PoEFunctionType::AlgebraicSigmoid {
-                max_rewards,
+                max_points,
                 a,
                 p,
                 s,
-            } => Ok(Box::new(AlgebraicSigmoid::new(max_rewards, a, p, s)?)),
+            } => Ok(Box::new(AlgebraicSigmoid::new(max_points, a, p, s)?)),
         }
     }
 }


### PR DESCRIPTION
Just so that it aligns better with the current naming for engagement points.