### PR TITLE
Mixer mixing fn benches

### DIFF
--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -20,7 +20,6 @@ bench = false
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
-benches = [ "cosmwasm-vm" ]
 
 [dependencies]
 cosmwasm-std = "1.0.0"
@@ -38,11 +37,10 @@ tg4 = { path = "../../packages/tg4", version = "0.10.0" }
 tg-utils = { path = "../../packages/utils", version = "0.10.0" }
 tg-bindings = { path = "../../packages/bindings", version = "0.10.0" }
 
-# bench dependencies
-cosmwasm-vm = { version = "1.0.0", optional = true }
-
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
+# bench dependencies
+cosmwasm-vm = { version = "1.0.0" }
 cw-multi-test = "0.13.4"
 tg4-engagement = { path = "../tg4-engagement", version = "0.10.0", features = ["library"] }
 tg4-stake = { path = "../tg4-stake", version = "0.10.0", features = ["library"] }
@@ -50,4 +48,3 @@ tg4-stake = { path = "../tg4-stake", version = "0.10.0", features = ["library"] 
 [[bench]]
 name = "main"
 harness = false
-required-features = [ "benches" ]

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -3,11 +3,25 @@
 //! Then running `cargo bench` will validate we can properly call into that generated Wasm.
 //!
 use cosmwasm_std::{Decimal, Uint64};
-use cosmwasm_vm::from_slice;
-use cosmwasm_vm::testing::{mock_env, mock_instance, query};
+use cosmwasm_vm::testing::{
+    mock_env, mock_instance_with_options, query, MockApi, MockInstanceOptions,
+    MockQuerier, MockStorage,
+};
+use cosmwasm_vm::{features_from_csv, from_slice, Instance};
 
 use tg4_mixer::msg::PoEFunctionType::{AlgebraicSigmoid, GeometricMean, Sigmoid, SigmoidSqrt};
 use tg4_mixer::msg::{MixerFunctionResponse, QueryMsg};
+
+fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQuerier> {
+    mock_instance_with_options(
+        wasm,
+        MockInstanceOptions {
+            supported_features: features_from_csv("iterator,tgrade"),
+            gas_limit: 100_000_000_000_000,
+            ..Default::default()
+        },
+    )
+}
 
 // Output of cargo wasm
 static WASM: &[u8] =
@@ -24,7 +38,7 @@ fn main() {
     const STAKE: u64 = 100000;
     const ENGAGEMENT: u64 = 5000;
 
-    let mut deps = mock_instance(WASM, &[]);
+    let mut deps = mock_instance_on_tgrade(WASM);
 
     let max_points = Uint64::new(MAX_POINTS);
     let a = Decimal::from_ratio(37u128, 10u128);

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -4,8 +4,8 @@
 //!
 use cosmwasm_std::{Decimal, Uint64};
 use cosmwasm_vm::testing::{
-    mock_env, mock_instance_with_options, query, MockApi, MockInstanceOptions,
-    MockQuerier, MockStorage,
+    mock_env, mock_instance_with_options, query, MockApi, MockInstanceOptions, MockQuerier,
+    MockStorage,
 };
 use cosmwasm_vm::{features_from_csv, from_slice, Instance};
 
@@ -48,12 +48,12 @@ fn main() {
 
     println!();
     for (poe_fn_name, poe_fn, result, gas) in [
-        ("GeometricMean", GeometricMean {}, 22360, 5893350000),
+        ("GeometricMean", GeometricMean {}, 22360, 5900100000),
         (
             "Sigmoid",
             Sigmoid { max_points, p, s },
             MAX_POINTS,
-            91848300000,
+            89959950000,
         ),
         (
             "SigmoidSqrt",
@@ -62,7 +62,7 @@ fn main() {
                 s: s_sqrt,
             },
             997,
-            21120000000,
+            20597550000,
         ),
         (
             "AlgebraicSigmoid",
@@ -73,7 +73,7 @@ fn main() {
                 s,
             },
             996,
-            86607900000,
+            85284750000,
         ),
     ] {
         let benchmark_msg = QueryMsg::MixerFunction {


### PR DESCRIPTION
Updates the mixing function benchmark setup / values to latest version of deps.

These are the current gas costs, by the way:
```
$ cbench --locked
...

   GeometricMean(100000, 5000) = 22360 ( 42 SDK gas)
         Sigmoid(100000, 5000) =  1000 (642 SDK gas)
     SigmoidSqrt(100000, 5000) =   997 (147 SDK gas)
AlgebraicSigmoid(100000, 5000) =   996 (609 SDK gas)
$ 
```