### PR TITLE
Add a PoE Sigmoid breaking point util

### DIFF
--- a/contracts/tg4-mixer/examples/poe_sigmoid_breaking.rs
+++ b/contracts/tg4-mixer/examples/poe_sigmoid_breaking.rs
@@ -1,0 +1,109 @@
+//! This example tries to run and call the generated wasm.
+//! It depends on a Wasm build being available, which you can create with `cargo wasm`.
+//! Then running `cargo example` will validate we can properly call into that generated Wasm.
+//!
+use cosmwasm_std::{Decimal, Uint64};
+use cosmwasm_vm::testing::{
+    mock_env, mock_instance_with_options, query, MockApi, MockInstanceOptions, MockQuerier,
+    MockStorage,
+};
+use cosmwasm_vm::{features_from_csv, Instance};
+
+use tg4_mixer::msg::PoEFunctionType::Sigmoid;
+use tg4_mixer::msg::QueryMsg;
+
+fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQuerier> {
+    mock_instance_with_options(
+        wasm,
+        MockInstanceOptions {
+            supported_features: features_from_csv("iterator,tgrade"),
+            gas_limit: 100_000_000_000_000_000,
+            ..Default::default()
+        },
+    )
+}
+
+// Output of cargo wasm
+static WASM: &[u8] =
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/tg4_mixer.wasm");
+
+fn main() {
+    const MAX_POINTS: u64 = 1000;
+    const ENGAGEMENT: u64 = 50000;
+
+    let mut deps = mock_instance_on_tgrade(WASM);
+
+    let max_points = Uint64::new(MAX_POINTS);
+
+    // Fixed engagement
+    let engagement = Uint64::new(ENGAGEMENT);
+
+    let min_stake = 1000000;
+    let step_stake = 10000;
+
+    println!();
+    println!("Sigmoid function breaking checks:");
+    for (s, p) in [
+        (
+            Decimal::from_ratio(3u128, 100000u128),
+            Decimal::from_ratio(68u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(5u128, 100000u128),
+            Decimal::from_ratio(55u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(2u128, 100000u128),
+            Decimal::from_ratio(57u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(1u128, 1000000u128),
+            Decimal::from_ratio(72u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(3u128, 100000u128),
+            Decimal::from_ratio(59u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(1u128, 100000u128),
+            Decimal::from_ratio(62u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(1u128, 1000000u128),
+            Decimal::from_ratio(741u128, 1000u128),
+        ),
+        (
+            Decimal::from_ratio(5u128, 100000u128),
+            Decimal::from_ratio(54u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(2u128, 100000u128),
+            Decimal::from_ratio(56u128, 100u128),
+        ),
+        (
+            Decimal::from_ratio(1u128, 1000000u128),
+            Decimal::from_ratio(707u128, 1000u128),
+        ),
+    ] {
+        let sigmoid_fn = Sigmoid { max_points, p, s };
+
+        for stake in (min_stake..).step_by(step_stake) {
+            let breaking_msg = QueryMsg::MixerFunction {
+                stake: Uint64::new(stake),
+                engagement,
+                poe_function: Some(sigmoid_fn.clone()),
+            };
+
+            let res = query(&mut deps, mock_env(), breaking_msg);
+
+            if res.is_err() {
+                println!(
+                    "Sigmoid(p={}, s={})(stake={}, engagement={}) broke.",
+                    p, s, stake, ENGAGEMENT
+                );
+                // println!("Error: {:#?}", res);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some maximum values of stake for the Sigmoid function.

Breaking point is inversely proportional to the `p` exponent.

```
$ cargo run --example poe_sigmoid_breaking
...

Sigmoid function breaking checks:
Sigmoid(p=0.68, s=0.00003)(stake=32320000, engagement=50000) broke.
Sigmoid(p=0.55, s=0.00005)(stake=1924550000, engagement=50000) broke.
Sigmoid(p=0.57, s=0.00002)(stake=909000000, engagement=50000) broke.
Sigmoid(p=0.72, s=0.000001)(stake=12370000, engagement=50000) broke.
Sigmoid(p=0.59, s=0.00003)(stake=451740000, engagement=50000) broke.
Sigmoid(p=0.62, s=0.00001)(stake=172230000, engagement=50000) broke.
Sigmoid(p=0.741, s=0.000001)(stake=7790000, engagement=50000) broke.
Sigmoid(p=0.54, s=0.00005)(stake=2859310000, engagement=50000) broke.
Sigmoid(p=0.56, s=0.00002)(stake=1313830000, engagement=50000) broke.
Sigmoid(p=0.707, s=0.000001)(stake=16700000, engagement=50000) broke.
$ 
```

As long as there are not more than 7M TGD in stake, the original `Sigmoid` works.