### PR TITLE
Verify validators revisited

### DIFF
--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -98,27 +98,27 @@ pub enum QueryMsg {
     Hooks {},
     /// Return the current number of preauths. Returns PreauthResponse.
     Preauths {},
-    /// Return how much rewards are assigned for withdrawal to given address. Returns
+    /// Return how many rewards are assigned for withdrawal from the given address. Returns
     /// `RewardsResponse`.
     WithdrawableRewards { owner: String },
-    /// Return how much rewards were distributed in total by this contract. Returns
+    /// Return how many rewards were distributed in total by this contract. Returns
     /// `RewardsResponse`.
     DistributedRewards {},
-    /// Return how much funds were send to this contract since last `ExecuteMsg::DistribtueFunds`,
-    /// and wait for distribution. Returns `RewardsResponse`.
+    /// Return how many funds were sent to this contract since last `ExecuteMsg::DistributeFunds`,
+    /// and await for distribution. Returns `RewardsResponse`.
     UndistributedRewards {},
-    /// Returns address allowed for withdrawal funds assigned to owner. Returns `DelegateResponse`
+    /// Return address allowed for withdrawal of the funds assigned to owner. Returns `DelegateResponse`
     Delegated { owner: String },
-    /// Returns information about the halflife, including the duration in seconds, the last
-    /// and the next occurence.
+    /// Returns information about the half-life, including the duration in seconds, the last
+    /// and the next occurrence.
     Halflife {},
-    /// Returns information (bool) whether given address is an active slasher
+    /// Returns information (bool) about whether the given address is an active slasher
     IsSlasher { addr: String },
-    /// Returns all active slashers as vector of addresses
+    /// Returns all active slashers as a vector of addresses
     ListSlashers {},
     /// Returns rewards distribution data
     DistributionData {},
-    /// Returns withdraw adjustment
+    /// Returns withdraw adjustment data
     WithdrawAdjustmentData { addr: String },
 }
 

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -943,6 +943,9 @@ pub fn migrate(
         if let Some(max_validators) = msg.max_validators {
             cfg.max_validators = max_validators;
         }
+        if let Some(verify_validators) = msg.verify_validators {
+            cfg.verify_validators = verify_validators;
+        }
         Ok(cfg)
     })?;
 

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -43,8 +43,8 @@ pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const REWARDS_INIT_REPLY_ID: u64 = 1;
 
-/// Number of missed blocks a validator can be jailed for.
-const MISSED_BLOCKS: u64 = 1000;
+/// Missed blocks interval a validator can be jailed for.
+pub const MISSED_BLOCKS: u64 = 1000;
 
 /// We use this custom message everywhere
 pub type Response = cosmwasm_std::Response<TgradeMsg>;
@@ -709,7 +709,7 @@ fn end_block(deps: DepsMut<TgradeQuery>, env: Env) -> Result<Response, ContractE
                 height = VALIDATOR_START_HEIGHT.may_load(deps.storage, &operator_addr)?;
             }
             match height {
-                Some(h) if h > env.block.height - MISSED_BLOCKS => {
+                Some(h) if h > env.block.height.saturating_sub(MISSED_BLOCKS) => {
                     // Validator is still active or recent, no need to jail
                     continue;
                 }

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -508,6 +508,7 @@ pub struct InstantiateResponse {
 pub struct MigrateMsg {
     pub min_points: Option<u64>,
     pub max_validators: Option<u32>,
+    pub verify_validators: Option<bool>,
 }
 
 #[cfg(test)]

--- a/contracts/tgrade-valset/src/multitest/migration.rs
+++ b/contracts/tgrade-valset/src/multitest/migration.rs
@@ -19,6 +19,7 @@ fn migration_can_alter_cfg() {
             &MigrateMsg {
                 min_points: Some(5),
                 max_validators: Some(10),
+                verify_validators: Some(true),
             },
         )
         .unwrap();

--- a/contracts/tgrade-valset/src/multitest/suite.rs
+++ b/contracts/tgrade-valset/src/multitest/suite.rs
@@ -494,6 +494,13 @@ impl Suite {
         Ok(diff)
     }
 
+    pub fn advance_blocks(&mut self, blocks: u64) -> AnyResult<Option<ValidatorDiff>> {
+        self.app.advance_blocks(blocks);
+        let (_, diff) = self.app.end_block()?;
+        self.app.begin_block(vec![])?;
+        Ok(diff)
+    }
+
     /// Timestamp of current block
     pub fn timestamp(&self) -> Timestamp {
         self.app.block_info().time

--- a/contracts/tgrade-valset/src/multitest/verify_online.rs
+++ b/contracts/tgrade-valset/src/multitest/verify_online.rs
@@ -123,7 +123,7 @@ fn verify_validators_jailing() {
 }
 
 #[test]
-fn validator_needs_to_verify_if_unjailed_1() {
+fn validator_needs_to_verify_if_unjailed() {
     let members = vec![
         "member1member1member1member1memb",
         "member2member2member2member2memb",

--- a/contracts/tgrade-valset/src/multitest/verify_online.rs
+++ b/contracts/tgrade-valset/src/multitest/verify_online.rs
@@ -1,9 +1,11 @@
 use std::convert::TryInto;
 
+use crate::contract::MISSED_BLOCKS;
 use cosmwasm_std::Binary;
 use tg_bindings::{Ed25519Pubkey, ToAddress, ValidatorVote};
 
 use crate::multitest::helpers::assert_active_validators;
+use crate::multitest::suite::Suite;
 
 use super::{
     helpers::{addr_to_pubkey, members_init},
@@ -28,7 +30,6 @@ fn verify_validators_works() {
     let mut suite = SuiteBuilder::new()
         .with_operators(&members)
         .with_engagement(&members_init(&members, &[2, 3]))
-        .with_min_points(1)
         .with_verify_validators(600)
         .build();
 
@@ -53,10 +54,10 @@ fn verify_validators_works() {
     assert!(info2.jailed_until.is_none());
     assert!(info1.active_validator);
     assert!(info2.active_validator);
-    // Validators have min power before they're verified
+    // Validators have full power from the beginning
     assert_active_validators(
         &suite.list_active_validators(None, None).unwrap(),
-        &[(members[0], 1), (members[1], 1)],
+        &[(members[0], 2), (members[1], 3)],
     );
 
     suite.advance_epoch().unwrap();
@@ -80,7 +81,7 @@ fn verify_validators_jailing() {
         "member2member2member2member2memb",
     ];
 
-    let mut suite = SuiteBuilder::new()
+    let mut suite: Suite = SuiteBuilder::new()
         .with_operators(&members)
         .with_engagement(&members_init(&members, &[2, 3]))
         .with_verify_validators(600)
@@ -94,13 +95,26 @@ fn verify_validators_jailing() {
         }])
         .unwrap();
 
+    // Initially no jailed validators
     let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
     let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
     assert!(info1.jailed_until.is_none());
     assert!(info2.jailed_until.is_none());
 
+    // Advance before the missed blocks interval
     suite.advance_epoch().unwrap();
 
+    // Still no jailed validators
+    let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
+    let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
+    assert!(info1.jailed_until.is_none());
+    assert!(info2.jailed_until.is_none());
+
+    // Advance after the missed blocks interval
+    suite.advance_blocks(MISSED_BLOCKS).unwrap();
+    suite.advance_epoch().unwrap();
+
+    // Validator who didn't vote for all the missed blocks period is now jailed
     let info1 = suite.validator(members[0]).unwrap().validator.unwrap();
     let info2 = suite.validator(members[1]).unwrap().validator.unwrap();
     assert!(info1.jailed_until.is_none());
@@ -109,7 +123,7 @@ fn verify_validators_jailing() {
 }
 
 #[test]
-fn validator_needs_to_verify_if_unjailed() {
+fn validator_needs_to_verify_if_unjailed_1() {
     let members = vec![
         "member1member1member1member1memb",
         "member2member2member2member2memb",
@@ -118,7 +132,6 @@ fn validator_needs_to_verify_if_unjailed() {
     let mut suite = SuiteBuilder::new()
         .with_operators(&members)
         .with_engagement(&members_init(&members, &[2, 3]))
-        .with_min_points(2)
         .with_verify_validators(600)
         .with_epoch_length(600)
         .build();
@@ -140,9 +153,10 @@ fn validator_needs_to_verify_if_unjailed() {
         .is_none());
     assert_active_validators(
         &suite.list_active_validators(None, None).unwrap(),
-        &[(members[0], 2), (members[1], 2)],
+        &[(members[0], 2), (members[1], 3)],
     );
 
+    suite.advance_blocks(MISSED_BLOCKS).unwrap();
     suite.advance_epoch().unwrap();
 
     // Validator 2 failed verification, so is jailed
@@ -173,12 +187,12 @@ fn validator_needs_to_verify_if_unjailed() {
         .is_none());
     assert_active_validators(
         &suite.list_active_validators(None, None).unwrap(),
-        &[(members[0], 2), (members[1], 2)],
+        &[(members[0], 2), (members[1], 3)],
     );
 
-    // Validator should be PENDING after being re-added to the valset,
-    // so if they fail to sign a block to prove they're online, they get
+    // If validator fails to sign a block to prove they're online, they get
     // jailed -again-
+    suite.advance_blocks(MISSED_BLOCKS).unwrap();
     suite.advance_epoch().unwrap();
     assert!(suite
         .validator(members[1])
@@ -203,9 +217,8 @@ fn validator_needs_to_verify_if_unjailed_by_auto_unjail() {
     let mut suite = SuiteBuilder::new()
         .with_operators(&members)
         .with_engagement(&members_init(&members, &[2, 3]))
-        .with_min_points(2)
         .with_auto_unjail()
-        .with_verify_validators(600)
+        .with_verify_validators(1200)
         .with_epoch_length(600)
         .build();
 
@@ -226,9 +239,11 @@ fn validator_needs_to_verify_if_unjailed_by_auto_unjail() {
         .is_none());
     assert_active_validators(
         &suite.list_active_validators(None, None).unwrap(),
-        &[(members[0], 2), (members[1], 2)],
+        &[(members[0], 2), (members[1], 3)],
     );
 
+    // Advance after the missed blocks interval
+    suite.advance_blocks(MISSED_BLOCKS).unwrap();
     suite.advance_epoch().unwrap();
 
     // Validator 2 failed verification, so is jailed
@@ -256,7 +271,7 @@ fn validator_needs_to_verify_if_unjailed_by_auto_unjail() {
         .is_none());
     assert_active_validators(
         &suite.list_active_validators(None, None).unwrap(),
-        &[(members[0], 2), (members[1], 2)],
+        &[(members[0], 2), (members[1], 3)],
     );
 
     // Validator should be PENDING after being re-added to the valset,

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -57,11 +57,8 @@ pub struct Config {
     /// Address of contract for validator group voting.
     pub validator_group: Addr,
 
-    /// When a validator joins the valset, verify they sign the first block since joining
-    /// or jail them for a period otherwise.
-    ///
-    /// The verification happens every time the validator becomes an active validator,
-    /// including when they are unjailed or when they just gain enough power to participate.
+    /// If this is enabled, signed blocks are watched for, and if a validator fails to sign any blocks
+    /// in a string of a number of blocks (typically 1000 blocks), they are jailed.
     pub verify_validators: bool,
 
     /// The duration to jail a validator for in case they don't sign their first epoch

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -108,6 +108,10 @@ pub const VALIDATORS: Item<Vec<ValidatorInfo>> = Item::new("validators");
 /// to verify they're online.
 pub const PENDING_VALIDATORS: Item<Vec<(Addr, Ed25519Pubkey)>> = Item::new("pending");
 
+/// A map of validators to block heights they had last signed a block.
+/// To verify they're online / active.
+pub const BLOCK_SIGNERS: Map<&Addr, u64> = Map::new("block_signers");
+
 /// Map of operator addr to block height it initially became a validator. If operator doesn't
 /// appear in this map, he was never in the validator set.
 pub const VALIDATOR_START_HEIGHT: Map<&Addr, u64> = Map::new("start_height");

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -110,7 +110,8 @@ pub const PENDING_VALIDATORS: Item<Vec<(Addr, Ed25519Pubkey)>> = Item::new("pend
 
 /// A map of validators to block heights they had last signed a block.
 /// To verify they're online / active.
-pub const BLOCK_SIGNERS: Map<&Addr, u64> = Map::new("block_signers");
+/// The key are the first 20 bytes of the SHA-256 hashed validator pubkey (from Cosmos SDK).
+pub const BLOCK_SIGNERS: Map<&[u8], u64> = Map::new("block_signers");
 
 /// Map of operator addr to block height it initially became a validator. If operator doesn't
 /// appear in this map, he was never in the validator set.

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -104,10 +104,6 @@ pub const EPOCH: Item<EpochInfo> = Item::new("epoch");
 /// This will be empty only on the first run.
 pub const VALIDATORS: Item<Vec<ValidatorInfo>> = Item::new("validators");
 
-/// A list of validators who have just became active and have yet to sign a block
-/// to verify they're online.
-pub const PENDING_VALIDATORS: Item<Vec<(Addr, Ed25519Pubkey)>> = Item::new("pending");
-
 /// A map of validators to block heights they had last signed a block.
 /// To verify they're online / active.
 /// The key are the first 20 bytes of the SHA-256 hashed validator pubkey (from Cosmos SDK).


### PR DESCRIPTION
Closes #149.

This implements a hash map of signing block heights per validator, so that a lack of signing interval (1000 blocks) can be detected, and the associated validator jailed.
This gets rid of the `PENDING_VALIDATORS` list, as now validators are accepted with their full power since the beginning, and jailed if they miss signing a string of blocks.

After the jailing period expires validators are re-instated (with `auto-unjail`), but will be jailed automatically if failing to sign blocks again.

Requires https://github.com/confio/tgrade/pull/428 to work. So, this will require a chain upgrade, not only the valset contract upgrade / migration. 

TODO:

- ~~Cache validator "addresses" (SHA256-20 hashes) for performance? Would require benchmarking / comparison of reading hashes from storage vs. computing them directly when needed.~~ (created #172 to address this in a different PR)
- ~~Migration code / tests. Existing `PENDING_VALIDATORS`, if any, need to be "promoted" to normal ones during migration, and the PENDING_VALIDATOR stuff must be emptied / removed.~~ (if `verify_validators` was never enabled, `PENDING_VALIDATORS` is empty. There's no need for related migration code then.)
- ~~A strategy must be devised to either populate the new `BLOCK_SIGNERS` map during migration with default / fallback values, or to execute the migration just after an epoch boundary (`env.block.time % epoch_length == 1`)~~. (The second option is preferred for simplicity).
- ~~Migration code can enable the `verify_validators` flag after a successful migration. That, or the `UpdateConfig` message needs to be modified to allow changing of this flag based on a validator-voting proposal~~. (migration code enables the functionality).