### PR TITLE
Benchmark `Ed25519Pubkey::to_address`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "cw-utils",
  "cw2",
  "derivative",
+ "hex-literal",
  "schemars",
  "semver",
  "serde",

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -48,12 +48,12 @@ fn main() {
 
     println!();
     for (poe_fn_name, poe_fn, result, gas) in [
-        ("GeometricMean", GeometricMean {}, 22360, 5900100000),
+        ("GeometricMean", GeometricMean {}, 22360, 5721600000),
         (
             "Sigmoid",
             Sigmoid { max_points, p, s },
             MAX_POINTS,
-            89959950000,
+            89547900000,
         ),
         (
             "SigmoidSqrt",
@@ -62,7 +62,7 @@ fn main() {
                 s: s_sqrt,
             },
             997,
-            20597550000,
+            20303550000,
         ),
         (
             "AlgebraicSigmoid",
@@ -73,7 +73,7 @@ fn main() {
                 s,
             },
             996,
-            85284750000,
+            84871200000,
         ),
     ] {
         let benchmark_msg = QueryMsg::MixerFunction {

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -17,6 +17,8 @@ exclude = [
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+# See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+bench = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
@@ -47,9 +49,16 @@ cosmwasm-vm = { version = "1.0.0", optional = true, default-features = false, fe
 anyhow = "1"
 assert_matches = "1.5"
 cosmwasm-schema = "1.0.0"
+# bench dependencies
+cosmwasm-vm = { version = "1.0.0" }
 cw-multi-test = "0.13.4"
 derivative = "2"
+hex-literal = "0.3"
 tg4-engagement = { path = "../tg4-engagement", version = "0.13.0" }
 tg4-stake = { path = "../tg4-stake", version = "0.13.0" }
 # we enable multitest feature only for tests
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.13.0" }
+
+[[bench]]
+name = "main"
+harness = false

--- a/contracts/tgrade-valset/benches/main.rs
+++ b/contracts/tgrade-valset/benches/main.rs
@@ -1,0 +1,66 @@
+//! This benchmark tries to run and call the generated wasm.
+//! It depends on a Wasm build being available, which you can create with `cargo wasm`.
+//! Then running `cargo bench` will validate we can properly call into that generated Wasm.
+//!
+use hex_literal::hex;
+use std::convert::TryFrom;
+
+use cosmwasm_vm::testing::{
+    execute, mock_env, mock_info, mock_instance_with_options, MockApi, MockInstanceOptions,
+    MockQuerier, MockStorage,
+};
+use cosmwasm_vm::{features_from_csv, Instance};
+
+use tg_bindings::{Ed25519Pubkey, Pubkey};
+use tgrade_valset::contract::Response;
+use tgrade_valset::msg::ExecuteMsg;
+
+fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQuerier> {
+    mock_instance_with_options(
+        wasm,
+        MockInstanceOptions {
+            supported_features: features_from_csv("iterator,tgrade"),
+            gas_limit: 100_000_000_000_000,
+            ..Default::default()
+        },
+    )
+}
+
+// Output of cargo wasm
+static WASM: &[u8] =
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/tgrade_valset.wasm");
+
+// From https://github.com/CosmWasm/wasmd/blob/master/x/wasm/keeper/gas_register.go#L31
+const GAS_MULTIPLIER: u64 = 140_000_000;
+
+const PUBKEY_HEX: [u8; 32] =
+    hex!("14253d61ef42d166d02e68d540d07fdf8d65a9af0acaa46302688e788a8521e2");
+
+fn main() {
+    let pubkey = Pubkey::Ed25519(PUBKEY_HEX.into());
+    let ed25519_pubkey = Ed25519Pubkey::try_from(pubkey).unwrap();
+
+    let mut deps = mock_instance_on_tgrade(WASM);
+
+    let to_address_msg = ExecuteMsg::PubkeyToAddress {
+        pubkey: ed25519_pubkey.clone(),
+    };
+    let gas_before = deps.get_gas_left();
+    let res: Response = execute(
+        &mut deps,
+        mock_env(),
+        mock_info("sender", &[]),
+        to_address_msg,
+    )
+    .unwrap();
+    let gas_used = gas_before - deps.get_gas_left();
+    let address = res.data.unwrap();
+    let sdk_gas = gas_used / GAS_MULTIPLIER;
+
+    println!(
+        "{} = {} ({} SDK gas)",
+        [ed25519_pubkey.to_base64(), ".to_address()".to_string()].concat(),
+        address,
+        sdk_gas
+    );
+}

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -23,7 +23,7 @@ use tg_bindings::{
 use tg_utils::{ensure_from_older_version, JailingDuration, SlashMsg, ADMIN};
 
 use crate::error::ContractError;
-use crate::migration::migrate_jailing_period;
+use crate::migration::{migrate_jailing_period, migrate_verify_validators};
 use crate::msg::{
     EpochResponse, ExecuteMsg, InstantiateMsg, InstantiateResponse, JailingEnd, JailingPeriod,
     ListActiveValidatorsResponse, ListValidatorResponse, ListValidatorSlashingResponse, MigrateMsg,
@@ -947,6 +947,8 @@ pub fn migrate(
     })?;
 
     migrate_jailing_period(deps.branch(), &original_version)?;
+
+    migrate_verify_validators(deps.branch(), &original_version)?;
 
     Ok(Response::new())
 }

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -179,6 +179,7 @@ pub fn execute(
         ExecuteMsg::SimulateValidatorSet { validators } => {
             execute_simulate_validators(deps, info, validators)
         }
+        ExecuteMsg::PubkeyToAddress { pubkey } => execute_pubkey_to_address(deps, info, pubkey),
     }
 }
 
@@ -401,6 +402,14 @@ fn execute_simulate_validators<Q: CustomQuery>(
     VALIDATORS.save(deps.storage, &validators)?;
 
     Ok(Response::new())
+}
+
+fn execute_pubkey_to_address<Q: CustomQuery>(
+    _deps: DepsMut<Q>,
+    _info: MessageInfo,
+    pubkey: Ed25519Pubkey,
+) -> Result<Response, ContractError> {
+    Ok(Response::new().set_data(pubkey.to_address()))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/tgrade-valset/src/migration.rs
+++ b/contracts/tgrade-valset/src/migration.rs
@@ -7,7 +7,7 @@ use tg_utils::Expiration;
 
 use crate::error::ContractError;
 use crate::msg::{JailingEnd, JailingPeriod};
-use crate::state::JAIL;
+use crate::state::{CONFIG, JAIL};
 
 /// `crate::msg::JailingPeriod` version from v0.6.2 and before
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -46,6 +46,21 @@ pub fn migrate_jailing_period<Q: CustomQuery>(
     for (addr, jailing_period) in jailings {
         JAIL.save(deps.storage, &addr, &jailing_period)?;
     }
+
+    Ok(())
+}
+
+pub fn migrate_verify_validators<Q: CustomQuery>(
+    deps: DepsMut<Q>,
+    version: &Version,
+) -> Result<(), ContractError> {
+    let mut config = if *version <= "0.14.0".parse::<Version>().unwrap() {
+        CONFIG.load(deps.storage)?
+    } else {
+        return Ok(());
+    };
+    config.verify_validators = true;
+    CONFIG.save(deps.storage, &config)?;
 
     Ok(())
 }

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -176,8 +176,13 @@ pub enum ExecuteMsg {
     },
 
     /// This will compute an address from a Ed25519 public key. Used for benchmarking.
-    /// Returns AddressResponse.
+    /// If cache is true, the address will be cached in the state.
     PubkeyToAddress {
+        pubkey: Ed25519Pubkey,
+        cache: bool,
+    },
+    /// This will read a stored address from a Ed25519 public key. Used for benchmarking.
+    ReadPubkeyAddress {
         pubkey: Ed25519Pubkey,
     },
 }

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -174,6 +174,12 @@ pub enum ExecuteMsg {
     SimulateValidatorSet {
         validators: Vec<ValidatorInfo>,
     },
+
+    /// This will compute an address from a Ed25519 public key. Used for benchmarking.
+    /// Returns AddressResponse.
+    PubkeyToAddress {
+        pubkey: Ed25519Pubkey,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/tgrade-valset/src/state.rs
+++ b/contracts/tgrade-valset/src/state.rs
@@ -117,6 +117,9 @@ pub const VALIDATOR_SLASHING: Map<&Addr, Vec<ValidatorSlashing>> = Map::new("val
 /// is not jailed
 pub const JAIL: Map<&Addr, JailingPeriod> = Map::new("jail");
 
+/// Map of Ed25519 pubkeys to their addresses.
+pub const ADDRESS_CACHE: Map<&[u8], [u8; 20]> = Map::new("address_cache");
+
 /// This stores the info for an operator. Both their Tendermint key as well as
 /// their metadata.
 #[derive(Serialize, Deserialize, Clone, JsonSchema, Debug, PartialEq)]


### PR DESCRIPTION
Closes #172.

Results are:

```
$ cbench
    Finished bench [optimized] target(s) in 0.10s
     Running unittests (/Users/mauro/work/poe-contracts/target/release/deps/main-2e693b0c907ad080)
FCU9Ye9C0WbQLmjVQNB/341lqa8KyqRjAmiOeIqFIeI=.to_address() = DNo/R+88SQZpOxcO9lDrloxfSyw= (not cached) (65 SDK gas)
FCU9Ye9C0WbQLmjVQNB/341lqa8KyqRjAmiOeIqFIeI=.to_address() = N/A (cache miss) (58 SDK gas)
FCU9Ye9C0WbQLmjVQNB/341lqa8KyqRjAmiOeIqFIeI=.to_address() = DNo/R+88SQZpOxcO9lDrloxfSyw= (cached) (72 SDK gas)
FCU9Ye9C0WbQLmjVQNB/341lqa8KyqRjAmiOeIqFIeI=.to_address() = DNo/R+88SQZpOxcO9lDrloxfSyw= (cache hit) (70 SDK gas)
$ 
```

As we can see, computing the hash is not only cheap, it's faster than reading it from storage.

Better NOT to merge this, as it extends `ExecuteMsg` with some otherwise useless benchmarking helpers.