### PR TITLE
Release 0.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
 jobs:
   contract_tg4_engagement:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tg4-engagement
     steps:
       - checkout:
@@ -51,7 +51,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tg4-engagement-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tg4-engagement-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -64,11 +64,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tg4-engagement-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tg4-engagement-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tg4_group:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tg4-group
     steps:
       - checkout:
@@ -78,7 +78,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tg4-group-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tg4-group-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -91,11 +91,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tg4-group-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tg4-group-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tg4_mixer:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tg4-mixer
     steps:
       - checkout:
@@ -105,7 +105,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tg4-mixer-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tg4-mixer-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -118,11 +118,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tg4-mixer-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tg4-mixer-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tg4_stake:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tg4-stake
     steps:
       - checkout:
@@ -132,7 +132,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tg4-stake-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tg4-stake-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -145,11 +145,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tg4-stake-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tg4-stake-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tgrade_gov_reflect:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tgrade-gov-reflect
     steps:
       - checkout:
@@ -159,7 +159,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tgrade-gov-reflect-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tgrade-gov-reflect-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -172,11 +172,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tgrade-gov-reflect-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tgrade-gov-reflect-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tgrade_valset:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tgrade-valset
     steps:
       - checkout:
@@ -186,7 +186,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tgrade-valset-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tgrade-valset-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -199,11 +199,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tgrade-valset-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tgrade-valset-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tgrade_validator_voting:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tgrade-validator-voting
     steps:
       - checkout:
@@ -213,7 +213,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tgrade-validator-voting-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tgrade-validator-voting-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -226,11 +226,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tgrade-validator-voting-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tgrade-validator-voting-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tgrade_vesting_account:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tgrade-vesting-account
     steps:
       - checkout:
@@ -240,7 +240,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tgrade-vesting-account-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tgrade-vesting-account-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -262,11 +262,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tgrade-vesting-account-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tgrade-vesting-account-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_tgrade_community_pool:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/tgrade-community-pool
     steps:
       - checkout:
@@ -276,7 +276,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-tgrade-validator-voting-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-tgrade-validator-voting-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -289,12 +289,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-tgrade-validator-voting-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-tgrade-validator-voting-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
 
   package_bindings:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/bindings
     steps:
       - checkout:
@@ -304,7 +304,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-bindings:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-bindings:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -318,11 +318,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-bindings:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-bindings:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_bindings_test:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/bindings-test
     steps:
       - checkout:
@@ -332,7 +332,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-bindings-test:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-bindings-test:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -343,11 +343,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-bindings-test:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-bindings-test:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_utils:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/utils
     steps:
       - checkout:
@@ -357,7 +357,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-utils:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-utils:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -368,11 +368,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-utils:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-utils:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_tg3:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/tg3
     steps:
       - checkout:
@@ -382,7 +382,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-tg3:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-tg3:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -396,12 +396,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-tg3:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-tg3:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
 
   package_tg4:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/tg4
     steps:
       - checkout:
@@ -411,7 +411,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-tg4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-tg4:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -425,11 +425,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-tg4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-tg4:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_voting_contract:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/voting-contract
     steps:
       - checkout:
@@ -439,7 +439,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-tg4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-tg4:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -453,11 +453,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-tg4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-tg4:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_test_utils:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project/packages/test-utils
     steps:
       - checkout:
@@ -467,7 +467,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-tg4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-tg4:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -478,11 +478,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-tg4:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-tg4:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     steps:
       - checkout
       - run:
@@ -490,7 +490,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.58.1-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.60.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -515,7 +515,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.58.1-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.60.0-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -523,7 +523,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     steps:
       - checkout:
           path: ~/project
@@ -532,7 +532,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -552,7 +552,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: |
@@ -610,7 +610,7 @@ jobs:
 
   build_and_upload_schemas:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.60.0
     working_directory: ~/project
     steps:
       - checkout:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.14.0...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.15.0...HEAD)
+
+## [v0.15.0](https://github.com/confio/poe-contracts/tree/v0.15.0) (2022-09-19)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.14.0...v0.15.0)
+
+**Closed issues:**
+
+- tgrade-valset: Wrong automatic jailing logic [\#184](https://github.com/confio/poe-contracts/issues/184)
+
+**Merged pull requests:**
+
+- tgrade-valset migrate contract update [\#186](https://github.com/confio/poe-contracts/pull/186) ([maurolacy](https://github.com/maurolacy))
+- Update config extensions [\#185](https://github.com/confio/poe-contracts/pull/185) ([maurolacy](https://github.com/maurolacy))
 
 ## [v0.14.0](https://github.com/confio/poe-contracts/tree/v0.14.0) (2022-09-13)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.26.1",
+ "gimli",
 ]
 
 [[package]]
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,17 +174,30 @@ checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+
+[[package]]
+name = "corosensei"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
+checksum = "10cb32eb596428347033db2da3028558ef8ec506ae00605932eef4b24972baa2"
 dependencies = [
- "digest",
+ "digest 0.10.5",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.3",
@@ -184,32 +206,47 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b36e527620a2a3e00e46b6e731ab6c9b68d11069c986f7d7be8eba79ef081a4"
+checksum = "0faf3a02389f78d6173b7e680751205015d5406f8abbaa9aa36fd216adc9f10d"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772e80bbad231a47a2068812b723a1ff81dd4a0d56c9391ac748177bea3a61da"
+checksum = "d5d13e9ee950418b0ac90a2579b8769640e0b07e6d06d9d5f5b512ba64265e5a"
 dependencies = [
+ "cosmwasm-schema-derive",
  "schemars",
+ "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d5e04d338db6af813d0633fe9ab6a5cd36ae83796ca769ae13d6910a5861df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875994993c2082a6fcd406937bf0fca21c349e4a624f3810253a14fa83a3a195"
+checksum = "b3409b349f282924c8099b554aae6fe70e4eb97d6a64697ae13c8be25a7eb158"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
  "schemars",
  "serde",
@@ -220,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18403b07304d15d304dad11040d45bbcaf78d603b4be3fb5e2685c16f9229b5"
+checksum = "f024880dd46c053f30dd31f3b3aab8197b5cfaafe86c9e302c845df0cff44a0a"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -230,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472bd6f037bf4de43a29f65ca5d66b8c06510fdb2cd9c911ed08b5a2cec3606f"
+checksum = "0551db61c7aa685e7b0a97bc250dc7e930c7805951d3aadc190402e42de63123"
 dependencies = [
  "clru",
  "cosmwasm-crypto",
@@ -243,7 +280,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "thiserror",
  "wasmer",
  "wasmer-middlewares",
@@ -260,24 +297,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6bea67967505247f54fa2c85cf4f6e0e31c4e5692c9b70e4ae58e339067333"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48194035d2752bdd5bdae429e3ab88676e95f52a2b1355a5d4e809f9e39b1d74"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
- "gimli 0.25.0",
+ "gimli",
  "log",
  "regalloc",
  "smallvec",
@@ -286,31 +323,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976efb22fcab4f2cd6bd4e9913764616a54d895c1a23530128d04e03633c555f"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dabb5fe66e04d4652e434195b45ae65b5c8172d520247b8f66d8df42b2b45dc"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3329733e4d4b8e91c809efcaa4faee80bf66f20164e3dd16d707346bd3494799"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.76.0"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279afcc0d3e651b773f94837c3d581177b348c8d69e928104b2e9fccb226f921"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -380,9 +416,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -391,13 +427,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
@@ -407,7 +443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -415,10 +451,11 @@ dependencies = [
 
 [[package]]
 name = "cw-controllers"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81b8c4647f13be38baea7345885fcd97cffe8ad4e0454a43f975be9609127ed"
+checksum = "0cc1bc794002a1e409e4a0c8aac8839f065fb387087d51b9efa94890b82c38e7"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "cw-utils",
@@ -429,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca153120cf5b91af88be106b0c6c0263423d959bc813b1592982c02c4691a4ae"
+checksum = "2519fd64b6b8c7c4e77c317e665bd19b438db3e8e4867241fa6a31cf060feda9"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -448,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8b264257c4f44c49b7ce09377af63aa040768ecd3fd7bdd2d48a09323a1e90"
+checksum = "39ba3fb5fad2dce94263d070848b2befc46b5c8e4929adfb9a3595267823d6ec"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -459,10 +496,11 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
+checksum = "7a67007ff056f4cd034f361c8ed69780c0180959b9c8037c84f3caa78120faf5"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw2",
  "schemars",
@@ -473,10 +511,11 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa74c324af8e3506fd8d50759a265bead3f87402e413c840042af5d2808463d6"
+checksum = "b0a1924a28607bf7cb9fd6681a64feea3e5fa9a8cb71fb4d24cf33635b21065a"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "schemars",
@@ -485,10 +524,11 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f446f59c519fbac5ab8b9f6c7f8dcaa05ee761703971406b28221ea778bb737"
+checksum = "56a48e4a85c0a31484e053a3eea15abfc3ed24fafc1a1a3e91181a0bd3a8ee91"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils",
  "schemars",
@@ -497,10 +537,11 @@ dependencies = [
 
 [[package]]
 name = "cw4"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95dcc5320bdee5475aadfe7ebce70be5d98040bf91b44b7c22d3acd0c133c329"
+checksum = "ce632c71b9e41aed1f9676ab864d77eb32b270a207ec60cf13d557346b32b751"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "schemars",
@@ -543,11 +584,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -568,6 +610,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -604,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "85789ce7dfbd0f0624c07ef653a08bb2ebf43d3e16531361f46d36dd54334fed"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -624,7 +677,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "zeroize",
 ]
@@ -637,16 +690,18 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
+ "digest 0.10.5",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -711,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -765,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -775,16 +830,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -832,12 +881,11 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.5",
 ]
 
 [[package]]
@@ -901,15 +949,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "3636d281d46c3b64182eb3a0a42b7b483191a2ecc3f05301fa67403f7c9bc949"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -1075,13 +1122,12 @@ checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -1222,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.31"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1263,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -1380,10 +1426,11 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",
@@ -1463,20 +1510,31 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signature"
-version = "1.3.2"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+dependencies = [
+ "digest 0.10.5",
  "rand_core 0.6.3",
 ]
 
@@ -1488,9 +1546,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
@@ -1547,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1555,12 +1613,12 @@ dependencies = [
  "hex-literal",
  "schemars",
  "serde",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1574,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1582,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1599,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1621,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "tg3"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1633,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1644,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1666,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1683,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1708,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1728,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1750,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1763,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1786,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1814,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1984,9 +2042,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmer"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f727a39e7161f7438ddb8eafe571b67c576a8c2fb459f666d9053b5bba4afdea"
+checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
 dependencies = [
  "cfg-if",
  "indexmap",
@@ -1996,6 +2054,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-compiler-singlepass",
@@ -2009,10 +2068,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-compiler"
-version = "2.2.1"
+name = "wasmer-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9951599222eb12bd13d4d91bcded0a880e4c22c2dfdabdf5dc7e5e803b7bf3"
+checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
+dependencies = [
+ "enumset",
+ "loupe",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
 dependencies = [
  "enumset",
  "loupe",
@@ -2023,20 +2095,19 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasmer-types",
- "wasmer-vm",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c83273bce44e668f3a2b9ccb7f1193db918b1d6806f64acc5ff71f6ece5f20"
+checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "gimli 0.25.0",
+ "gimli",
  "loupe",
  "more-asserts",
  "rayon",
@@ -2045,18 +2116,18 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5432e993840cdb8e6875ddc8c9eea64e7a129579b4706bd91b8eb474d9c4a860"
+checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
 dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
+ "gimli",
  "lazy_static",
  "loupe",
  "more-asserts",
@@ -2064,14 +2135,13 @@ dependencies = [
  "smallvec",
  "wasmer-compiler",
  "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
 name = "wasmer-derive"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458dbd9718a837e6dbc52003aef84487d79eedef5fa28c7d28b6784be98ac08e"
+checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2081,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed603a6d037ebbb14014d7f739ae996a78455a4b86c41cfa4e81c590a1253b9"
+checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
 dependencies = [
  "backtrace",
  "enumset",
@@ -2096,6 +2166,7 @@ dependencies = [
  "serde_bytes",
  "target-lexicon",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -2103,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-dylib"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd7fdc60e252a795c849b3f78a81a134783051407e7e279c10b7019139ef8dc"
+checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
 dependencies = [
  "cfg-if",
  "enum-iterator",
@@ -2118,6 +2189,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tracing",
+ "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-engine",
  "wasmer-object",
@@ -2128,12 +2200,11 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcff0cd2c01a8de6009fd863b14ea883132a468a24f2d2ee59dc34453d3a31b5"
+checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
 dependencies = [
  "cfg-if",
- "enum-iterator",
  "enumset",
  "leb128",
  "loupe",
@@ -2141,16 +2212,33 @@ dependencies = [
  "rkyv",
  "wasmer-compiler",
  "wasmer-engine",
+ "wasmer-engine-universal-artifact",
  "wasmer-types",
  "wasmer-vm",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-middlewares"
-version = "2.2.1"
+name = "wasmer-engine-universal-artifact"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659775db15684f4674c3a8967409682c2eb44f63cc21121fa3dcd975c03ab887"
+checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "loupe",
+ "rkyv",
+ "thiserror",
+ "wasmer-artifact",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-middlewares"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7812438ed2f37203a37007cdb5332b8475cb2b16e15d51299b2647894e9ed3a"
 dependencies = [
  "loupe",
  "wasmer",
@@ -2160,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-object"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ce18ac2877050e59580d27ee1a88f3192d7a31e77fbba0852abc7888d6e0b5"
+checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
 dependencies = [
  "object",
  "thiserror",
@@ -2172,12 +2260,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659fa3dd6c76f62630deff4ac8c7657b07f0b1e4d7e0f8243a552b9d9b448e24"
+checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
 dependencies = [
+ "backtrace",
+ "enum-iterator",
  "indexmap",
  "loupe",
+ "more-asserts",
  "rkyv",
  "serde",
  "thiserror",
@@ -2185,32 +2276,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdc46158517c2769f9938bc222a7d41b3bb330824196279d8aa2d667cd40641"
+checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
+ "corosensei",
  "enum-iterator",
  "indexmap",
+ "lazy_static",
  "libc",
  "loupe",
+ "mach",
  "memoffset",
  "more-asserts",
  "region",
  "rkyv",
+ "scopeguard",
  "serde",
  "thiserror",
+ "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "which"
@@ -2246,7 +2342,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "zeroize"
-version = "1.4.3"
+name = "windows-sys"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -21,10 +21,10 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-controllers = "0.14.0"
-cw-storage-plus = "0.14.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
+cw-controllers = "0.15.0"
+cw-storage-plus = "0.15.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
 tg-utils = { version = "0.14.0", path = "../../packages/utils" }
 tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
 tg4 = { path = "../../packages/tg4", version = "0.14.0" }
@@ -35,6 +35,6 @@ thiserror = "1.0.21"
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.0"
 derivative = "2"
 tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -20,7 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-controllers = "0.14.0"
 cw-storage-plus = "0.14.0"
 cw-utils = "0.14.0"
@@ -34,7 +34,7 @@ thiserror = "1.0.21"
 
 [dev-dependencies]
 anyhow = "1"
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.14.0"
 derivative = "2"
 tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -25,9 +25,9 @@ cw-controllers = "0.15.0"
 cw-storage-plus = "0.15.0"
 cw-utils = "0.15.0"
 cw2 = "0.15.0"
-tg-utils = { version = "0.14.0", path = "../../packages/utils" }
-tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
-tg4 = { path = "../../packages/tg4", version = "0.14.0" }
+tg-utils = { version = "0.15.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.15.0", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.15.0" }
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.21"
@@ -37,4 +37,4 @@ anyhow = "1"
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
 derivative = "2"
-tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.15.0", path = "../../packages/bindings-test" }

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -26,7 +26,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw2 = "0.14.0"
 cw4 = "0.14.0"
@@ -38,4 +38,4 @@ tg4 = { version = "0.14.0", path = "../../packages/tg4" }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-group"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Mauro Lacy <mauro@confio.gmbh>"]
 edition = "2018"
 description = "Simple tg4 implementation of group membership controlled by admin"
@@ -34,7 +34,7 @@ cw-controllers = "0.15.0"
 cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { version = "0.14.0", path = "../../packages/tg4" }
+tg4 = { version = "0.15.0", path = "../../packages/tg4" }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -27,11 +27,11 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
-cw4 = "0.14.0"
-cw-controllers = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
+cw4 = "0.15.0"
+cw-controllers = "0.15.0"
+cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg4 = { version = "0.14.0", path = "../../packages/tg4" }

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -23,10 +23,10 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
-cw20 = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
+cw20 = "0.15.0"
+cw-storage-plus = "0.15.0"
 integer-sqrt = "0.1.5"
 rust_decimal = { version = "1.16", default-features = false, features = ["maths"] }
 rust_decimal_macros = { version = "1.16", default-features = false }
@@ -41,7 +41,7 @@ tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
 cosmwasm-schema = "1.1.0"
 # bench dependencies
 cosmwasm-vm = { version = "1.1.0" }
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.0"
 tg4-engagement = { path = "../tg4-engagement", version = "0.14.0", features = ["library"] }
 tg4-stake = { path = "../tg4-stake", version = "0.14.0", features = ["library"] }
 

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -33,17 +33,17 @@ rust_decimal_macros = { version = "1.16", default-features = false }
 thiserror = "1.0.21"
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../../packages/tg4", version = "0.14.0" }
-tg-utils = { path = "../../packages/utils", version = "0.14.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
+tg4 = { path = "../../packages/tg4", version = "0.15.0" }
+tg-utils = { path = "../../packages/utils", version = "0.15.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.15.0" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"
 # bench dependencies
 cosmwasm-vm = { version = "1.1.0" }
 cw-multi-test = "0.15.0"
-tg4-engagement = { path = "../tg4-engagement", version = "0.14.0", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.14.0", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.15.0", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.15.0", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -22,7 +22,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw2 = "0.14.0"
 cw20 = "0.14.0"
@@ -38,9 +38,9 @@ tg-utils = { path = "../../packages/utils", version = "0.14.0" }
 tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 # bench dependencies
-cosmwasm-vm = { version = "1.0.0" }
+cosmwasm-vm = { version = "1.1.0" }
 cw-multi-test = "0.14.0"
 tg4-engagement = { path = "../tg4-engagement", version = "0.14.0", features = ["library"] }
 tg4-stake = { path = "../tg4-stake", version = "0.14.0", features = ["library"] }

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -48,12 +48,12 @@ fn main() {
 
     println!();
     for (poe_fn_name, poe_fn, result, gas) in [
-        ("GeometricMean", GeometricMean {}, 22360, 5721600000),
+        ("GeometricMean", GeometricMean {}, 22360, 5729550000),
         (
             "Sigmoid",
             Sigmoid { max_points, p, s },
             MAX_POINTS,
-            89547900000,
+            89533650000,
         ),
         (
             "SigmoidSqrt",
@@ -62,7 +62,7 @@ fn main() {
                 s: s_sqrt,
             },
             997,
-            20303550000,
+            20300700000,
         ),
         (
             "AlgebraicSigmoid",
@@ -73,7 +73,7 @@ fn main() {
                 s,
             },
             996,
-            84871200000,
+            84850050000,
         ),
     ] {
         let benchmark_msg = QueryMsg::MixerFunction {

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -7,7 +7,7 @@ use cosmwasm_vm::testing::{
     mock_env, mock_instance_with_options, query, MockApi, MockInstanceOptions, MockQuerier,
     MockStorage,
 };
-use cosmwasm_vm::{features_from_csv, from_slice, Instance};
+use cosmwasm_vm::{capabilities_from_csv, from_slice, Instance};
 
 use tg4_mixer::msg::PoEFunctionType::{AlgebraicSigmoid, GeometricMean, Sigmoid, SigmoidSqrt};
 use tg4_mixer::msg::{MixerFunctionResponse, QueryMsg};
@@ -16,7 +16,7 @@ fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQu
     mock_instance_with_options(
         wasm,
         MockInstanceOptions {
-            supported_features: features_from_csv("iterator,tgrade"),
+            available_capabilities: capabilities_from_csv("iterator,tgrade"),
             gas_limit: 100_000_000_000_000,
             ..Default::default()
         },

--- a/contracts/tg4-mixer/benches/main.rs
+++ b/contracts/tg4-mixer/benches/main.rs
@@ -48,7 +48,7 @@ fn main() {
 
     println!();
     for (poe_fn_name, poe_fn, result, gas) in [
-        ("GeometricMean", GeometricMean {}, 22360, 5729550000),
+        ("GeometricMean", GeometricMean {}, 22360, 5729550000i64),
         (
             "Sigmoid",
             Sigmoid { max_points, p, s },
@@ -99,6 +99,10 @@ fn main() {
             "{} result",
             poe_fn_name
         );
-        assert_eq!(gas, gas_used, "{} gas", poe_fn_name);
+        assert!(
+            (gas - gas_used as i64).abs() < gas / 10,
+            "{} gas",
+            poe_fn_name
+        );
     }
 }

--- a/contracts/tg4-mixer/src/member_indexes.rs
+++ b/contracts/tg4-mixer/src/member_indexes.rs
@@ -32,7 +32,7 @@ impl<'a> IndexList<MemberInfo> for MemberIndexes<'a> {
 pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, MemberInfo, MemberIndexes<'a>> {
     let indexes = MemberIndexes {
         points_tie_break: MultiIndex::new(
-            |mi| (mi.points, mi.start_height.map_or(i64::MIN, |h| -(h as i64))), // Works as long as `start_height <= i64::MAX + 1`
+            |_, mi| (mi.points, mi.start_height.map_or(i64::MIN, |h| -(h as i64))), // Works as long as `start_height <= i64::MAX + 1`
             tg4::MEMBERS_KEY,
             "members__points_tie_break",
         ),

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -28,11 +28,11 @@ cw-storage-plus = "0.15.0"
 itertools = "0.10"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../../packages/tg4", version = "0.14.0" }
-tg-utils = { path = "../../packages/utils", version = "0.14.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
+tg4 = { path = "../../packages/tg4", version = "0.15.0" }
+tg-utils = { path = "../../packages/utils", version = "0.15.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.15.0" }
 thiserror = "1.0.21"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.15.0" }

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -20,7 +20,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw2 = "0.14.0"
 cw-controllers = "0.14.0"
@@ -34,5 +34,5 @@ tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
 thiserror = "1.0.21"
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -21,10 +21,10 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
-cw-controllers = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
+cw-controllers = "0.15.0"
+cw-storage-plus = "0.15.0"
 itertools = "0.10"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/tg4-stake/src/claim.rs
+++ b/contracts/tg4-stake/src/claim.rs
@@ -72,7 +72,7 @@ impl<'a> Claims<'a> {
     pub fn new(storage_key: &'a str, release_subkey: &'a str) -> Self {
         let indexes = ClaimIndexes {
             release_at: MultiIndex::new(
-                |claim| claim.release_at.as_key(),
+                |_, claim| claim.release_at.as_key(),
                 storage_key,
                 release_subkey,
             ),

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -22,16 +22,16 @@ cw-utils = "0.15.0"
 cw2 = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
-tg-utils = { path = "../../packages/utils", version = "0.14.0" }
-tg-voting-contract = { version = "0.14.0", path = "../../packages/voting-contract" }
-tg3 = { path = "../../packages/tg3", version = "0.14.0" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.14.0", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.15.0" }
+tg-utils = { path = "../../packages/utils", version = "0.15.0" }
+tg-voting-contract = { version = "0.15.0", path = "../../packages/voting-contract" }
+tg3 = { path = "../../packages/tg3", version = "0.15.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.15.0", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
-tg4 = { path = "../../packages/tg4", version = "0.14.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.15.0" }
+tg4 = { path = "../../packages/tg4", version = "0.15.0" }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -18,8 +18,8 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
@@ -32,6 +32,6 @@ thiserror = "1"
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.0"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
 tg4 = { path = "../../packages/tg4", version = "0.14.0" }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -17,7 +17,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw2 = "0.14.0"
 schemars = "0.8.1"
@@ -31,7 +31,7 @@ thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.14.0"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
 tg4 = { path = "../../packages/tg4", version = "0.14.0" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -24,7 +24,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-storage-plus = "0.14.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -32,4 +32,4 @@ tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
 thiserror = "1"
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-gov-reflect voting contract"
@@ -28,7 +28,7 @@ cosmwasm-std = "1.1.0"
 cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
+tg-bindings = { version = "0.15.0", path = "../../packages/bindings" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -25,7 +25,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-storage-plus = "0.14.0"
+cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -22,10 +22,10 @@ cw-utils = "0.15.0"
 cw2 = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
-tg-utils = { path = "../../packages/utils", version = "0.14.0" }
-tg-voting-contract = { version = "0.14.0", path = "../../packages/voting-contract" }
-tg3 = { path = "../../packages/tg3", version = "0.14.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.15.0" }
+tg-utils = { path = "../../packages/utils", version = "0.15.0" }
+tg-voting-contract = { version = "0.15.0", path = "../../packages/voting-contract" }
+tg3 = { path = "../../packages/tg3", version = "0.15.0" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -33,8 +33,8 @@ anyhow = "1"
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
 cw-storage-plus = "0.15.0"
-tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.14.0", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.14.0", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.14.0" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.14.0", features = ["library"] }
+tg-bindings-test = { version = "0.15.0", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.15.0", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.15.0", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.15.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.15.0", features = ["library"] }

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -18,8 +18,8 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 tg-bindings = { path = "../../packages/bindings", version = "0.14.0" }
@@ -31,8 +31,8 @@ thiserror = "1"
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-multi-test = "0.15.0"
+cw-storage-plus = "0.15.0"
 tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }
 tg-utils = { version = "0.14.0", path = "../../packages/utils" }
 tg-voting-contract = { version = "0.14.0", path = "../../packages/voting-contract" }

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -17,7 +17,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw2 = "0.14.0"
 schemars = "0.8.1"
@@ -30,7 +30,7 @@ thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.14.0"
 cw-storage-plus = "0.14.0"
 tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -35,9 +35,9 @@ schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.21"
-tg4 = { path = "../../packages/tg4", version = "0.14.0" }
-tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.14.0", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.15.0" }
+tg-bindings = { version = "0.15.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.15.0", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
@@ -49,7 +49,7 @@ assert_matches = "1.5"
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
 derivative = "2"
-tg4-engagement = { path = "../tg4-engagement", version = "0.14.0" }
-tg4-stake = { path = "../tg4-stake", version = "0.14.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.15.0" }
+tg4-stake = { path = "../tg4-stake", version = "0.15.0" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.15.0" }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -27,10 +27,10 @@ integration = ["bech32", "cosmwasm-vm"]
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw2 = "0.14.0"
-cw-utils = "0.14.0"
-cw-controllers = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw2 = "0.15.0"
+cw-utils = "0.15.0"
+cw-controllers = "0.15.0"
+cw-storage-plus = "0.15.0"
 schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -47,7 +47,7 @@ cosmwasm-vm = { version = "1.1.0", optional = true, default-features = false, fe
 anyhow = "1"
 assert_matches = "1.5"
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.0"
 derivative = "2"
 tg4-engagement = { path = "../tg4-engagement", version = "0.14.0" }
 tg4-stake = { path = "../tg4-stake", version = "0.14.0" }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -26,7 +26,7 @@ library = []
 integration = ["bech32", "cosmwasm-vm"]
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw2 = "0.14.0"
 cw-utils = "0.14.0"
 cw-controllers = "0.14.0"
@@ -41,12 +41,12 @@ tg-utils = { version = "0.14.0", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
-cosmwasm-vm = { version = "1.0.0", optional = true, default-features = false, features = ["iterator"] }
+cosmwasm-vm = { version = "1.1.0", optional = true, default-features = false, features = ["iterator"] }
 
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1.5"
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.14.0"
 derivative = "2"
 tg4-engagement = { path = "../tg4-engagement", version = "0.14.0" }

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -17,9 +17,9 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw2 = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-utils = "0.15.0"
+cw2 = "0.15.0"
+cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
@@ -31,5 +31,5 @@ anyhow = "1"
 assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.0"
 tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "0.15.0"
 cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.14.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.15.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.15.0", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
-tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.15.0", path = "../../packages/bindings-test" }

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw2 = "0.14.0"
 cw-storage-plus = "0.14.0"
@@ -30,6 +30,6 @@ thiserror = "1"
 anyhow = "1"
 assert_matches = "1"
 derivative = "2"
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.14.0"
 tg-bindings-test = { version = "0.14.0", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -15,5 +15,5 @@ cw-multi-test = "0.15.0"
 cw-storage-plus = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.14.0", path = "../bindings" }
+tg-bindings = { version = "0.15.0", path = "../bindings" }
 thiserror = "1.0.21"

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-multi-test = "0.14.0"
 cw-storage-plus = "0.14.0"
 schemars = "0.8"

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1"
 cosmwasm-std = "1.1.0"
-cw-multi-test = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-multi-test = "0.15.0"
+cw-storage-plus = "0.15.0"
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg-bindings = { version = "0.14.0", path = "../bindings" }

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -10,11 +10,11 @@ license = "Apache-2.0"
 
 [dependencies]
 base64 = "0.13"
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 schemars = "0.8"
 sha2 = "0.9"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 hex-literal = "0.3.1"

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 tg-voting-contract = { path = "../voting-contract", version = "0.14.0" }

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-tg-voting-contract = { path = "../voting-contract", version = "0.14.0" }
+tg-voting-contract = { path = "../voting-contract", version = "0.15.0" }

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg3"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Tgrade-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 cosmwasm-std = "1.1.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.14.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.15.0", path = "../../packages/bindings" }
+tg-utils = { version = "0.15.0", path = "../../packages/utils" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -9,11 +9,11 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg-bindings = { version = "0.14.0", path = "../../packages/bindings" }
 tg-utils = { version = "0.14.0", path = "../../packages/utils" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = "1.1.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.14.0" }
+tg-bindings = { path = "../bindings", version = "0.15.0" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.0"

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -9,10 +9,10 @@ homepage = "https://tgrade.finance"
 license = "Apache-2.0"
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 tg-bindings = { path = "../bindings", version = "0.14.0" }
 
 [dev-dependencies]
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw-controllers = "0.14.0"
 cw-storage-plus = "0.14.0"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -19,6 +19,6 @@ cw2 = "0.15.0"
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.14.0" }
-tg-bindings = { path = "../bindings", version = "0.14.0" }
+tg4 = { path = "../tg4", version = "0.15.0" }
+tg-bindings = { path = "../bindings", version = "0.15.0" }
 thiserror = "1.0.21"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -12,10 +12,10 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw-controllers = "0.14.0"
-cw-storage-plus = "0.14.0"
-cw2 = "0.14.0"
+cw-utils = "0.15.0"
+cw-controllers = "0.15.0"
+cw-storage-plus = "0.15.0"
+cw2 = "0.15.0"
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/packages/utils/src/member_indexes.rs
+++ b/packages/utils/src/member_indexes.rs
@@ -32,7 +32,7 @@ impl<'a> IndexList<MemberInfo> for MemberIndexes<'a> {
 /// The points index is not snapshotted; only the current points are indexed at any given time.
 pub fn members<'a>() -> IndexedSnapshotMap<'a, &'a Addr, MemberInfo, MemberIndexes<'a>> {
     let indexes = MemberIndexes {
-        points: MultiIndex::new(|mi| mi.points, tg4::MEMBERS_KEY, "members__points"),
+        points: MultiIndex::new(|_, mi| mi.points, tg4::MEMBERS_KEY, "members__points"),
     };
     IndexedSnapshotMap::new(
         tg4::MEMBERS_KEY,

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.1.0"
-cw-utils = "0.14.0"
-cw-storage-plus = "0.14.0"
+cw-utils = "0.15.0"
+cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
 tg3 = { path = "../../packages/tg3", version = "0.14.0" }
@@ -25,7 +25,7 @@ thiserror = "1"
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.1.0"
-cw-multi-test = "0.14.0"
+cw-multi-test = "0.15.0"
 derivative = "2"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
 tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.14.0", features = ["library"] }

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -16,10 +16,10 @@ cw-utils = "0.15.0"
 cw-storage-plus = "0.15.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg3 = { path = "../../packages/tg3", version = "0.14.0" }
-tg4 = { path = "../tg4", version = "0.14.0" }
-tg-bindings = { path = "../bindings", version = "0.14.0" }
-tg-utils = { version = "0.14.0", path = "../utils" }
+tg3 = { path = "../../packages/tg3", version = "0.15.0" }
+tg4 = { path = "../tg4", version = "0.15.0" }
+tg-bindings = { path = "../bindings", version = "0.15.0" }
+tg-utils = { version = "0.15.0", path = "../utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.15.0"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.14.0", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.15.0" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.15.0", features = ["library"] }

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-std = "1.0.0"
+cosmwasm-std = "1.1.0"
 cw-utils = "0.14.0"
 cw-storage-plus = "0.14.0"
 schemars = "0.8.1"
@@ -24,7 +24,7 @@ thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
-cosmwasm-schema = "1.0.0"
+cosmwasm-schema = "1.1.0"
 cw-multi-test = "0.14.0"
 derivative = "2"
 tg-bindings-test = { path = "../../packages/bindings-test", version = "0.14.0" }

--- a/packages/voting-contract/src/ballots.rs
+++ b/packages/voting-contract/src/ballots.rs
@@ -34,7 +34,11 @@ pub struct Ballots<'a> {
 impl<'a> Ballots<'a> {
     pub fn new(storage_key: &'a str, release_subkey: &'a str) -> Self {
         let indexes = BallotIndexes {
-            voter: MultiIndex::new(|ballot| ballot.voter.clone(), storage_key, release_subkey),
+            voter: MultiIndex::new(
+                |_, ballot| ballot.voter.clone(),
+                storage_key,
+                release_subkey,
+            ),
         };
         let ballots = IndexedMap::new(storage_key, indexes);
 


### PR DESCRIPTION
Maintenance release. Just to update deps to latest cw and cw-plus versions. And sync up version numbers.

**Update**: will include required valset update / migration changes (related to #182) in this release.