### PR TITLE
Add promote / demote contract to privileged gov proposal

### DIFF
--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -150,6 +150,20 @@ pub fn execute_execute<Q: CustomQuery>(
                 proposal: GovProposal::ChangeParams(params),
             })
         }
+        PromoteToPrivilegedContract { contract } => {
+            res = res.add_message(TgradeMsg::ExecuteGovProposal {
+                title: proposal.title,
+                description: proposal.description,
+                proposal: GovProposal::PromoteToPrivilegedContract { contract },
+            })
+        }
+        DemotePrivilegedContract { contract } => {
+            res = res.add_message(TgradeMsg::ExecuteGovProposal {
+                title: proposal.title,
+                description: proposal.description,
+                proposal: GovProposal::DemotePrivilegedContract { contract },
+            })
+        }
     };
 
     Ok(res

--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -164,6 +164,26 @@ pub fn execute_execute<Q: CustomQuery>(
                 proposal: GovProposal::DemotePrivilegedContract { contract },
             })
         }
+        SetContractAdmin {
+            contract,
+            new_admin,
+        } => {
+            res = res.add_message(TgradeMsg::ExecuteGovProposal {
+                title: proposal.title,
+                description: proposal.description,
+                proposal: GovProposal::SetContractAdmin {
+                    contract,
+                    new_admin,
+                },
+            })
+        }
+        ClearContractAdmin { contract } => {
+            res = res.add_message(TgradeMsg::ExecuteGovProposal {
+                title: proposal.title,
+                description: proposal.description,
+                proposal: GovProposal::ClearContractAdmin { contract },
+            })
+        }
     };
 
     Ok(res

--- a/contracts/tgrade-validator-voting/src/error.rs
+++ b/contracts/tgrade-validator-voting/src/error.rs
@@ -50,6 +50,9 @@ pub enum ContractError {
 
     #[error("Invalid consensus params: All cannot be none")]
     InvalidConsensusParams {},
+
+    #[error("Empty new admin")]
+    EmptyAdmin {},
 }
 
 impl From<tg_voting_contract::ContractError> for ContractError {

--- a/contracts/tgrade-validator-voting/src/msg.rs
+++ b/contracts/tgrade-validator-voting/src/msg.rs
@@ -91,6 +91,16 @@ pub enum ValidatorProposal {
         /// The contract address to be demoted
         contract: String,
     },
+    SetContractAdmin {
+        /// The contract address to be updated
+        contract: String,
+        /// The account address to become migrate admin of this contract
+        new_admin: String,
+    },
+    ClearContractAdmin {
+        /// The contract address to be cleared
+        contract: String,
+    },
 }
 
 // We can also add this as a tg3 extension

--- a/contracts/tgrade-validator-voting/src/msg.rs
+++ b/contracts/tgrade-validator-voting/src/msg.rs
@@ -83,6 +83,14 @@ pub enum ValidatorProposal {
     Text {},
     /// Defines a proposal to change one or more parameters.
     ChangeParams(Vec<ParamChange>),
+    PromoteToPrivilegedContract {
+        /// The contract address to be promoted
+        contract: String,
+    },
+    DemotePrivilegedContract {
+        /// The contract address to be demoted
+        contract: String,
+    },
 }
 
 // We can also add this as a tg3 extension

--- a/contracts/tgrade-validator-voting/src/validate.rs
+++ b/contracts/tgrade-validator-voting/src/validate.rs
@@ -83,7 +83,10 @@ impl ValidatorProposal {
                     return Err(ContractError::InvalidConsensusParams {});
                 }
             }
-            ValidatorProposal::CancelUpgrade {} | ValidatorProposal::Text {} => {}
+            ValidatorProposal::PromoteToPrivilegedContract { .. }
+            | ValidatorProposal::DemotePrivilegedContract { .. }
+            | ValidatorProposal::CancelUpgrade {}
+            | ValidatorProposal::Text {} => {}
         }
         Ok(())
     }

--- a/contracts/tgrade-validator-voting/src/validate.rs
+++ b/contracts/tgrade-validator-voting/src/validate.rs
@@ -83,7 +83,16 @@ impl ValidatorProposal {
                     return Err(ContractError::InvalidConsensusParams {});
                 }
             }
-            ValidatorProposal::PromoteToPrivilegedContract { .. }
+            ValidatorProposal::SetContractAdmin {
+                contract: _contract,
+                new_admin,
+            } => {
+                if new_admin.is_empty() {
+                    return Err(ContractError::EmptyAdmin {});
+                }
+            }
+            ValidatorProposal::ClearContractAdmin { .. }
+            | ValidatorProposal::PromoteToPrivilegedContract { .. }
             | ValidatorProposal::DemotePrivilegedContract { .. }
             | ValidatorProposal::CancelUpgrade {}
             | ValidatorProposal::Text {} => {}


### PR DESCRIPTION
Closes part of #158:

- `PromoteToPrivilegedContract`.
- `DemotePrivilegedContract`.
- `SetContractAdmin`.
- `ClearContractAdmin`.



