### PR TITLE
Fix/contract name

### DIFF
--- a/contracts/tgrade-validator-voting/src/contract.rs
+++ b/contracts/tgrade-validator-voting/src/contract.rs
@@ -284,7 +284,11 @@ fn privilege_change(change: PrivilegeChangeMsg) -> Response {
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
-    ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    ensure_from_older_version(
+        deps.storage,
+        "crates.io:tgrade_validator_voting_proposals",
+        CONTRACT_VERSION,
+    )?;
     Ok(Response::new())
 }
 

--- a/scripts/optimizer.sh
+++ b/scripts/optimizer.sh
@@ -1,7 +1,7 @@
 :
 
 U="cosmwasm"
-V="0.12.7"
+V="0.12.8"
 
 M=$(uname -m)
 A="linux/${M/x86_64/amd64}"


### PR DESCRIPTION
A small change to allow migrating `tgrade-validator-voting` from an old (<= 0.11) version, which is the one currently on chain.