### PR TITLE
Add MigrateMsg with update config options

### DIFF
--- a/contracts/tg4-stake/examples/schema.rs
+++ b/contracts/tg4-stake/examples/schema.rs
@@ -5,8 +5,8 @@ use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, s
 
 pub use tg4::{AdminResponse, MemberListResponse, MemberResponse, TotalPointsResponse};
 pub use tg4_stake::msg::{
-    ClaimsResponse, ExecuteMsg, InstantiateMsg, PreauthResponse, QueryMsg, StakedResponse,
-    UnbondingPeriodResponse,
+    ClaimsResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, PreauthResponse, QueryMsg,
+    StakedResponse, UnbondingPeriodResponse,
 };
 
 fn main() {
@@ -18,6 +18,7 @@ fn main() {
     export_schema_with_title(&schema_for!(InstantiateMsg), &out_dir, "InstantiateMsg");
     export_schema_with_title(&schema_for!(ExecuteMsg), &out_dir, "ExecuteMsg");
     export_schema_with_title(&schema_for!(QueryMsg), &out_dir, "QueryMsg");
+    export_schema_with_title(&schema_for!(MigrateMsg), &out_dir, "MigrateMsg");
     export_schema(&schema_for!(AdminResponse), &out_dir);
     export_schema(&schema_for!(MemberListResponse), &out_dir);
     export_schema(&schema_for!(MemberResponse), &out_dir);

--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -715,6 +715,11 @@ pub fn migrate(
 
     CONFIG.update::<_, StdError>(deps.storage, |mut cfg| {
         if let Some(tokens_per_point) = msg.tokens_per_point {
+            let tokens_per_point = if tokens_per_point == Uint128::zero() {
+                Uint128::new(1)
+            } else {
+                tokens_per_point
+            };
             cfg.tokens_per_point = tokens_per_point;
         }
         if let Some(min_bond) = msg.min_bond {

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -135,6 +135,15 @@ pub struct ClaimsResponse {
     pub claims: Vec<Claim>,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {
+    pub tokens_per_point: Option<Uint128>,
+    pub min_bond: Option<Uint128>,
+    pub unbonding_period: Option<u64>,
+    pub auto_return_limit: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Add the ability for `migrate()` to update config values.

Needed for emergency disabling buggy `auto_return_limit`.