### PR TITLE
Engagement half-life

### DIFF
--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -913,7 +913,11 @@ fn list_members_by_points<Q: CustomQuery>(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(
+    deps: DepsMut<TgradeQuery>,
+    _env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, ContractError> {
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     if let Some(duration) = msg.halflife {
         // Update half life's duration

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -917,9 +917,14 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     if let Some(duration) = msg.halflife {
         // Update half life's duration
+        // Zero duration means no / remove half life
         HALFLIFE.update(deps.storage, |hf| -> StdResult<_> {
             Ok(Halflife {
-                halflife: Some(duration),
+                halflife: if duration.seconds() > 0 {
+                    Some(duration)
+                } else {
+                    None
+                },
                 last_applied: hf.last_applied,
             })
         })?;

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, to_binary, Addr, BankMsg, Binary, Coin, CustomQuery, Decimal, Deps, DepsMut, Empty, Env,
-    Event, MessageInfo, Order, StdResult, Timestamp, Uint128,
+    coin, to_binary, Addr, BankMsg, Binary, Coin, CustomQuery, Decimal, Deps, DepsMut, Env, Event,
+    MessageInfo, Order, StdResult, Timestamp, Uint128,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
@@ -14,8 +14,8 @@ use tg4::{
 
 use crate::error::ContractError;
 use crate::msg::{
-    DelegatedResponse, ExecuteMsg, HalflifeInfo, HalflifeResponse, InstantiateMsg, PreauthResponse,
-    QueryMsg, RewardsResponse, SudoMsg,
+    DelegatedResponse, ExecuteMsg, HalflifeInfo, HalflifeResponse, InstantiateMsg, MigrateMsg,
+    PreauthResponse, QueryMsg, RewardsResponse, SudoMsg,
 };
 use crate::state::{
     Distribution, Halflife, WithdrawAdjustment, DISTRIBUTION, HALFLIFE, PREAUTH_SLASHING,
@@ -913,8 +913,17 @@ fn list_members_by_points<Q: CustomQuery>(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    if let Some(duration) = msg.halflife {
+        // Update half life's duration
+        HALFLIFE.update(deps.storage, |hf| -> StdResult<_> {
+            Ok(Halflife {
+                halflife: Some(duration),
+                last_applied: hf.last_applied,
+            })
+        })?;
+    };
     Ok(Response::new())
 }
 

--- a/contracts/tg4-engagement/src/msg.rs
+++ b/contracts/tg4-engagement/src/msg.rs
@@ -183,6 +183,12 @@ pub struct ListSlashersResponse {
     pub slashers: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {
+    pub halflife: Option<Duration>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/tg4-engagement/src/multitest.rs
+++ b/contracts/tg4-engagement/src/multitest.rs
@@ -921,3 +921,31 @@ mod slashing {
         assert_eq!(suite.token_balance(members[2]).unwrap(), 0);
     }
 }
+
+mod migration {
+    use super::*;
+    use crate::msg::MigrateMsg;
+
+    #[test]
+    fn migration_can_alter_cfg() {
+        let mut suite = SuiteBuilder::new()
+            .with_halflife(Duration::new(100))
+            .build();
+        let admin = suite.admin().to_string();
+
+        let cfg = suite.halflife().unwrap();
+        assert_eq!(cfg.halflife_info.unwrap().halflife, Duration::new(100));
+
+        suite
+            .migrate(
+                &admin,
+                &MigrateMsg {
+                    halflife: Some(Duration::new(200)),
+                },
+            )
+            .unwrap();
+
+        let cfg = suite.halflife().unwrap();
+        assert_eq!(cfg.halflife_info.unwrap().halflife.seconds(), 200);
+    }
+}

--- a/contracts/tg4-engagement/src/multitest.rs
+++ b/contracts/tg4-engagement/src/multitest.rs
@@ -948,4 +948,27 @@ mod migration {
         let cfg = suite.halflife().unwrap();
         assert_eq!(cfg.halflife_info.unwrap().halflife.seconds(), 200);
     }
+
+    #[test]
+    fn migration_can_remove_halflife() {
+        let mut suite = SuiteBuilder::new()
+            .with_halflife(Duration::new(100))
+            .build();
+        let admin = suite.admin().to_string();
+
+        let cfg = suite.halflife().unwrap();
+        assert_eq!(cfg.halflife_info.unwrap().halflife, Duration::new(100));
+
+        suite
+            .migrate(
+                &admin,
+                &MigrateMsg {
+                    halflife: Some(Duration::new(0)),
+                },
+            )
+            .unwrap();
+
+        let cfg = suite.halflife().unwrap();
+        assert!(cfg.halflife_info.is_none());
+    }
 }


### PR DESCRIPTION
Add support for changing the half-life parameter through a contract migration.

This is not currently needed, but can be useful in the future. Made these changes because of some tests / checks I'm running in testnet.