### PR TITLE
Add undelegations processing to migration handler

### DIFF
--- a/contracts/tg4-stake/src/contract.rs
+++ b/contracts/tg4-stake/src/contract.rs
@@ -7,6 +7,7 @@ use cosmwasm_std::{
 use std::cmp::min;
 use std::ops::Sub;
 
+use crate::claim::process_pending_undelegations;
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use cw_utils::{ensure_from_older_version, maybe_addr};
@@ -756,7 +757,12 @@ pub fn migrate(
         Ok(cfg)
     })?;
 
-    Ok(Response::new())
+    if let Some(undelegations) = msg.undelegations {
+        let msgs = process_pending_undelegations(deps.as_ref(), &undelegations)?;
+        Ok(Response::new().add_messages(msgs))
+    } else {
+        Ok(Response::new())
+    }
 }
 
 #[cfg(test)]

--- a/contracts/tg4-stake/src/msg.rs
+++ b/contracts/tg4-stake/src/msg.rs
@@ -135,6 +135,12 @@ pub struct ClaimsResponse {
     pub claims: Vec<Claim>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct Undelegation {
+    pub addr: String,
+    pub amount: Uint128,
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {
@@ -142,6 +148,7 @@ pub struct MigrateMsg {
     pub min_bond: Option<Uint128>,
     pub unbonding_period: Option<u64>,
     pub auto_return_limit: Option<u64>,
+    pub undelegations: Option<Vec<Undelegation>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Needed as part of repairing the auto-release claims bug (#198).