### PR TITLE
Add half-life event member updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,6 +1744,7 @@ dependencies = [
  "cw2 1.0.0",
  "derivative",
  "schemars",
+ "semver",
  "serde",
  "tg-bindings",
  "tg-bindings-test",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -29,6 +29,7 @@ tg-utils = { version = "0.17.0", path = "../../packages/utils" }
 tg-bindings = { version = "0.17.0", path = "../../packages/bindings" }
 tg4 = { path = "../../packages/tg4", version = "0.17.0" }
 schemars = "0.8"
+semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.21"
 

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1627,12 +1627,17 @@ mod tests {
 
         // register a hook, to check for half life side effects
         let contract1 = String::from("hook1");
+        let contract2 = String::from("hook2");
 
         let admin_info = mock_info(INIT_ADMIN, &[]);
         let hook_msg = ExecuteMsg::AddHook {
             addr: contract1.clone(),
         };
-        let _ = execute(deps.as_mut(), mock_env(), admin_info, hook_msg).unwrap();
+        let hook_msg2 = ExecuteMsg::AddHook {
+            addr: contract2.clone(),
+        };
+        let _ = execute(deps.as_mut(), mock_env(), admin_info.clone(), hook_msg).unwrap();
+        let _ = execute(deps.as_mut(), mock_env(), admin_info, hook_msg2).unwrap();
 
         // end block just before half life time is met - do nothing
         env.block.time = env.block.time.plus_seconds(HALFLIFE - 2);
@@ -1663,7 +1668,8 @@ mod tests {
         };
         let resp = Response::new()
             .add_event(evt)
-            .add_message(msg.into_cosmos_msg(contract1).unwrap());
+            .add_message(msg.clone().into_cosmos_msg(contract1).unwrap())
+            .add_message(msg.into_cosmos_msg(contract2).unwrap());
         assert_eq!(end_block(deps.as_mut(), env.clone()), Ok(resp));
         assert_users(
             &deps,

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -552,14 +552,12 @@ pub fn update_members<Q: CustomQuery>(
         let add_addr = deps.api.addr_validate(&add.addr)?;
 
         let mut diff = 0;
-        let mut insert_funds = false;
         members().update(deps.storage, &add_addr, height, |old| -> StdResult<_> {
             diffs.push(MemberDiff::new(
                 add.addr,
                 old.as_ref().map(|mi| mi.points),
                 Some(add.points),
             ));
-            insert_funds = old.is_none();
             let old = old.unwrap_or_default();
             total -= old.points;
             total += add.points;

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -13,6 +13,7 @@ use tg4::{
 };
 
 use crate::error::ContractError;
+use crate::migration::migrate_config;
 use crate::msg::{
     DelegatedResponse, ExecuteMsg, HalflifeInfo, HalflifeResponse, InstantiateMsg, MigrateMsg,
     PreauthResponse, QueryMsg, RewardsResponse, SudoMsg,
@@ -928,20 +929,9 @@ pub fn migrate(
     msg: MigrateMsg,
 ) -> Result<Response, ContractError> {
     ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    if let Some(duration) = msg.halflife {
-        // Update half life's duration
-        // Zero duration means no / remove half life
-        HALFLIFE.update(deps.storage, |hf| -> StdResult<_> {
-            Ok(Halflife {
-                halflife: if duration.seconds() > 0 {
-                    Some(duration)
-                } else {
-                    None
-                },
-                last_applied: hf.last_applied,
-            })
-        })?;
-    };
+
+    migrate_config(deps, msg)?;
+
     Ok(Response::new())
 }
 

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1625,6 +1625,15 @@ mod tests {
         do_instantiate(deps.as_mut());
         let mut env = mock_env();
 
+        // register a hook, to check for half life side effects
+        let contract1 = String::from("hook1");
+
+        let admin_info = mock_info(INIT_ADMIN, &[]);
+        let hook_msg = ExecuteMsg::AddHook {
+            addr: contract1.clone(),
+        };
+        let _ = execute(deps.as_mut(), mock_env(), admin_info, hook_msg).unwrap();
+
         // end block just before half life time is met - do nothing
         env.block.time = env.block.time.plus_seconds(HALFLIFE - 2);
         assert_eq!(end_block(deps.as_mut(), env.clone()), Ok(Response::new()));

--- a/contracts/tg4-engagement/src/contract.rs
+++ b/contracts/tg4-engagement/src/contract.rs
@@ -1719,17 +1719,20 @@ mod tests {
         assert_users(&deps, Some(USER1_POINTS), Some(USER2_POINTS), None, None);
 
         // migration
-        let evt =
-            Event::new("halflife-updates").add_attribute("height", env.block.height.to_string());
-        let msg = MemberChangedHookMsg {
-            diffs: vec![
-                MemberDiff::new(USER1, Some(USER1_POINTS), Some(USER1_POINTS)),
-                MemberDiff::new(USER2, Some(USER2_POINTS), Some(USER2_POINTS)),
-            ],
-        };
-        let resp = Response::new()
-            .add_event(evt)
-            .add_message(msg.into_cosmos_msg(contract1).unwrap());
+        let mut resp = Response::new();
+        if CONTRACT_VERSION <= "0.17.0" {
+            let evt = Event::new("halflife-updates")
+                .add_attribute("height", env.block.height.to_string());
+            let msg = MemberChangedHookMsg {
+                diffs: vec![
+                    MemberDiff::new(USER1, Some(USER1_POINTS), Some(USER1_POINTS)),
+                    MemberDiff::new(USER2, Some(USER2_POINTS), Some(USER2_POINTS)),
+                ],
+            };
+            resp = resp
+                .add_event(evt)
+                .add_message(msg.into_cosmos_msg(contract1).unwrap());
+        }
         assert_eq!(
             migrate(deps.as_mut(), env, MigrateMsg { halflife: None }),
             Ok(resp)

--- a/contracts/tg4-engagement/src/lib.rs
+++ b/contracts/tg4-engagement/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contract;
 pub mod error;
 pub mod helpers;
 pub mod i128;
+pub mod migration;
 pub mod msg;
 #[cfg(test)]
 mod multitest;

--- a/contracts/tg4-engagement/src/migration.rs
+++ b/contracts/tg4-engagement/src/migration.rs
@@ -62,7 +62,7 @@ pub fn generate_pending_member_updates(
     for member in members_to_update {
         diffs.push(MemberDiff::new(
             member.addr.clone(),
-            Some(member.points), // FIXME: These are not the old points on the remote side
+            Some(member.points * 2), // FIXME: The parity bit is lost!
             Some(member.points),
         ));
     }

--- a/contracts/tg4-engagement/src/migration.rs
+++ b/contracts/tg4-engagement/src/migration.rs
@@ -1,8 +1,12 @@
+use cosmwasm_std::{Deps, DepsMut, Order, StdResult};
+
+use tg4::{Member, MemberChangedHookMsg, MemberDiff, MemberInfo};
+use tg_bindings::TgradeQuery;
+use tg_utils::members;
+
 use crate::error::ContractError;
 use crate::msg::MigrateMsg;
 use crate::state::{Halflife, HALFLIFE};
-use cosmwasm_std::{DepsMut, StdResult};
-use tg_bindings::TgradeQuery;
 
 pub(crate) fn migrate_config(
     deps: DepsMut<TgradeQuery>,
@@ -23,4 +27,45 @@ pub(crate) fn migrate_config(
         })?;
     }
     Ok(())
+}
+
+// Helper to repair the half life bug (#203)
+pub fn generate_pending_member_updates(
+    deps: Deps<TgradeQuery>,
+) -> Result<MemberChangedHookMsg, ContractError> {
+    // Iterate over all the members, and send an update member message to each of the registered hooks
+    let members_to_update: Vec<_> = members()
+        .range(deps.storage, None, None, Order::Ascending)
+        .filter_map(|item| {
+            (move || -> StdResult<Option<_>> {
+                let (
+                    addr,
+                    MemberInfo {
+                        points,
+                        start_height,
+                    },
+                ) = item?;
+                if points <= 1 {
+                    return Ok(None);
+                }
+                Ok(Some(Member {
+                    addr: addr.into(),
+                    points,
+                    start_height,
+                }))
+            })()
+            .transpose()
+        })
+        .collect::<StdResult<_>>()?;
+
+    let mut diffs: Vec<MemberDiff> = vec![];
+    for member in members_to_update {
+        diffs.push(MemberDiff::new(
+            member.addr.clone(),
+            Some(member.points), // FIXME: These are not the old points on the remote side
+            Some(member.points),
+        ));
+    }
+
+    Ok(MemberChangedHookMsg { diffs })
 }

--- a/contracts/tg4-engagement/src/migration.rs
+++ b/contracts/tg4-engagement/src/migration.rs
@@ -62,7 +62,7 @@ pub fn generate_pending_member_updates(
     for member in members_to_update {
         diffs.push(MemberDiff::new(
             member.addr.clone(),
-            Some(member.points * 2), // FIXME: The parity bit is lost!
+            Some(member.points),
             Some(member.points),
         ));
     }

--- a/contracts/tg4-engagement/src/migration.rs
+++ b/contracts/tg4-engagement/src/migration.rs
@@ -1,0 +1,26 @@
+use crate::error::ContractError;
+use crate::msg::MigrateMsg;
+use crate::state::{Halflife, HALFLIFE};
+use cosmwasm_std::{DepsMut, StdResult};
+use tg_bindings::TgradeQuery;
+
+pub(crate) fn migrate_config(
+    deps: DepsMut<TgradeQuery>,
+    msg: MigrateMsg,
+) -> Result<(), ContractError> {
+    if let Some(duration) = msg.halflife {
+        // Update half life's duration
+        // Zero duration means no / remove half life
+        HALFLIFE.update(deps.storage, |hf| -> StdResult<_> {
+            Ok(Halflife {
+                halflife: if duration.seconds() > 0 {
+                    Some(duration)
+                } else {
+                    None
+                },
+                last_applied: hf.last_applied,
+            })
+        })?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #203.

Opted for straightforward changes for the fix, instead of a full refactoring. `Member.points` is unsigned, and adding more complexity to `update_members` doesn't look like a good idea. In fact, perhaps it would be better to break down `update_members` into `add_members` and `remove_members` (as suggested in the past), and then add  a new `halve_members` in parallel.

TODO:

 - ~~Unit tests~~. (done)
 - ~~Migration handler update member msgs fixing code~~ (done).