### PR TITLE
Release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## [Unreleased](https://github.com/confio/poe-contracts/tree/HEAD)
 
-[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.17.0...HEAD)
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.17.1...HEAD)
+
+## [v0.17.1](https://github.com/confio/poe-contracts/tree/v0.17.1) (2023-01-25)
+
+[Full Changelog](https://github.com/confio/poe-contracts/compare/v0.17.0...v0.17.1)
+
+**Fixed bugs:**
+
+- \[tg4-engagement\] Half-life process does not update members [\#203](https://github.com/confio/poe-contracts/issues/203)
+
+**Merged pull requests:**
+
+- Add half-life event member updates [\#204](https://github.com/confio/poe-contracts/pull/204) ([maurolacy](https://github.com/maurolacy))
 
 ## [v0.17.0](https://github.com/confio/poe-contracts/tree/v0.17.0) (2023-01-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "base64",
  "cosmwasm-schema",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "tg-bindings-test"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "tg-test-utils"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-std",
  "tg-voting-contract",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "tg-utils"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "tg-voting-contract"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "tg3"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "tg4"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-engagement"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-group"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-mixer"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "tg4-stake"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-community-pool"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-gov-reflect"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-validator-voting"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-valset"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "tgrade-vesting-account"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/contracts/tg4-engagement/Cargo.toml
+++ b/contracts/tg4-engagement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-engagement"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Simple TG4 implementation of group membership controlled by an admin"
@@ -25,9 +25,9 @@ cw-controllers = "1.0.0"
 cw-storage-plus = "1.0.1"
 cw-utils = "1.0.1"
 cw2 = "1.0.0"
-tg-utils = { version = "0.17.0", path = "../../packages/utils" }
-tg-bindings = { version = "0.17.0", path = "../../packages/bindings" }
-tg4 = { path = "../../packages/tg4", version = "0.17.0" }
+tg-utils = { version = "0.17.1", path = "../../packages/utils" }
+tg-bindings = { version = "0.17.1", path = "../../packages/bindings" }
+tg4 = { path = "../../packages/tg4", version = "0.17.1" }
 schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
@@ -38,4 +38,4 @@ anyhow = "1"
 cosmwasm-schema = "1.1.9"
 cw-multi-test = "0.16.2"
 derivative = "2"
-tg-bindings-test = { version = "0.17.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.17.1", path = "../../packages/bindings-test" }

--- a/contracts/tg4-group/Cargo.toml
+++ b/contracts/tg4-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-group"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Mauro Lacy <mauro@confio.gmbh>"]
 edition = "2018"
 description = "Simple tg4 implementation of group membership controlled by admin"
@@ -34,7 +34,7 @@ cw-controllers = "1.0.0"
 cw-storage-plus = "1.0.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { version = "0.17.0", path = "../../packages/tg4" }
+tg4 = { version = "0.17.1", path = "../../packages/tg4" }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]

--- a/contracts/tg4-mixer/Cargo.toml
+++ b/contracts/tg4-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-mixer"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation that combines two different groups with a merge function"
@@ -33,17 +33,17 @@ rust_decimal_macros = { version = "1.16", default-features = false }
 thiserror = "1.0.21"
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../../packages/tg4", version = "0.17.0" }
-tg-utils = { path = "../../packages/utils", version = "0.17.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.17.0" }
+tg4 = { path = "../../packages/tg4", version = "0.17.1" }
+tg-utils = { path = "../../packages/utils", version = "0.17.1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.17.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.9"
 # bench dependencies
 cosmwasm-vm = { version = "1.1.0" }
 cw-multi-test = "0.16.2"
-tg4-engagement = { path = "../tg4-engagement", version = "0.17.0", features = ["library"] }
-tg4-stake = { path = "../tg4-stake", version = "0.17.0", features = ["library"] }
+tg4-engagement = { path = "../tg4-engagement", version = "0.17.1", features = ["library"] }
+tg4-stake = { path = "../tg4-stake", version = "0.17.1", features = ["library"] }
 
 [[bench]]
 name = "main"

--- a/contracts/tg4-stake/Cargo.toml
+++ b/contracts/tg4-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4-stake"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "TG4 implementation of group based on staked tokens"
@@ -28,11 +28,11 @@ cw-storage-plus = "1.0.1"
 itertools = "0.10"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../../packages/tg4", version = "0.17.0" }
-tg-utils = { path = "../../packages/utils", version = "0.17.0" }
-tg-bindings = { path = "../../packages/bindings", version = "0.17.0" }
+tg4 = { path = "../../packages/tg4", version = "0.17.1" }
+tg-utils = { path = "../../packages/utils", version = "0.17.1" }
+tg-bindings = { path = "../../packages/bindings", version = "0.17.1" }
 thiserror = "1.0.21"
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.9"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.1" }

--- a/contracts/tgrade-community-pool/Cargo.toml
+++ b/contracts/tgrade-community-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-community-pool"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Implementing tgrade-community-pool voting contract"
@@ -22,16 +22,16 @@ cw-utils = "1.0.1"
 cw2 = "1.0.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.17.0" }
-tg-utils = { path = "../../packages/utils", version = "0.17.0" }
-tg-voting-contract = { version = "0.17.0", path = "../../packages/voting-contract" }
-tg3 = { path = "../../packages/tg3", version = "0.17.0" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.17.0", features = ["library"] }
+tg-bindings = { path = "../../packages/bindings", version = "0.17.1" }
+tg-utils = { path = "../../packages/utils", version = "0.17.1" }
+tg-voting-contract = { version = "0.17.1", path = "../../packages/voting-contract" }
+tg3 = { path = "../../packages/tg3", version = "0.17.1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.17.1", features = ["library"] }
 thiserror = "1"
 
 [dev-dependencies]
 anyhow = "1"
 cosmwasm-schema = "1.1.9"
 cw-multi-test = "0.16.2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.0" }
-tg4 = { path = "../../packages/tg4", version = "0.17.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.1" }
+tg4 = { path = "../../packages/tg4", version = "0.17.1" }

--- a/contracts/tgrade-gov-reflect/Cargo.toml
+++ b/contracts/tgrade-gov-reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-gov-reflect"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-gov-reflect voting contract"
@@ -28,7 +28,7 @@ cosmwasm-std = "1.1.9"
 cw-storage-plus = "1.0.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.17.0", path = "../../packages/bindings" }
+tg-bindings = { version = "0.17.1", path = "../../packages/bindings" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/contracts/tgrade-validator-voting/Cargo.toml
+++ b/contracts/tgrade-validator-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-validator-voting"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implementing tgrade-validator-voting"
@@ -22,10 +22,10 @@ cw-utils = "1.0.1"
 cw2 = "1.0.0"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../../packages/bindings", version = "0.17.0" }
-tg-utils = { path = "../../packages/utils", version = "0.17.0" }
-tg-voting-contract = { version = "0.17.0", path = "../../packages/voting-contract" }
-tg3 = { path = "../../packages/tg3", version = "0.17.0" }
+tg-bindings = { path = "../../packages/bindings", version = "0.17.1" }
+tg-utils = { path = "../../packages/utils", version = "0.17.1" }
+tg-voting-contract = { version = "0.17.1", path = "../../packages/voting-contract" }
+tg3 = { path = "../../packages/tg3", version = "0.17.1" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -33,8 +33,8 @@ anyhow = "1"
 cosmwasm-schema = "1.1.9"
 cw-multi-test = "0.16.2"
 cw-storage-plus = "1.0.1"
-tg-bindings-test = { version = "0.17.0", path = "../../packages/bindings-test" }
-tg-utils = { version = "0.17.0", path = "../../packages/utils" }
-tg-voting-contract = { version = "0.17.0", path = "../../packages/voting-contract" }
-tg4 = { path = "../../packages/tg4", version = "0.17.0" }
-tg4-engagement = { path = "../tg4-engagement", version = "0.17.0", features = ["library"] }
+tg-bindings-test = { version = "0.17.1", path = "../../packages/bindings-test" }
+tg-utils = { version = "0.17.1", path = "../../packages/utils" }
+tg-voting-contract = { version = "0.17.1", path = "../../packages/voting-contract" }
+tg4 = { path = "../../packages/tg4", version = "0.17.1" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.17.1", features = ["library"] }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-valset"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Control the validator set based on membership of trusted tg4 contract"
@@ -35,9 +35,9 @@ schemars = "0.8"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = "1.0.21"
-tg4 = { path = "../../packages/tg4", version = "0.17.0" }
-tg-bindings = { version = "0.17.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.17.0", path = "../../packages/utils" }
+tg4 = { path = "../../packages/tg4", version = "0.17.1" }
+tg-bindings = { version = "0.17.1", path = "../../packages/bindings" }
+tg-utils = { version = "0.17.1", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
@@ -49,7 +49,7 @@ assert_matches = "1.5"
 cosmwasm-schema = "1.1.9"
 cw-multi-test = "0.16.2"
 derivative = "2"
-tg4-engagement = { path = "../tg4-engagement", version = "0.17.0" }
-tg4-stake = { path = "../tg4-stake", version = "0.17.0" }
+tg4-engagement = { path = "../tg4-engagement", version = "0.17.1" }
+tg4-stake = { path = "../tg4-stake", version = "0.17.1" }
 # we enable multitest feature only for tests
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.0" }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.1" }

--- a/contracts/tgrade-vesting-account/Cargo.toml
+++ b/contracts/tgrade-vesting-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tgrade-vesting-account"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Vesting Account as a contract"
@@ -22,8 +22,8 @@ cw2 = "1.0.0"
 cw-storage-plus = "1.0.1"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.17.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.17.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.17.1", path = "../../packages/bindings" }
+tg-utils = { version = "0.17.1", path = "../../packages/utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -32,4 +32,4 @@ assert_matches = "1"
 derivative = "2"
 cosmwasm-schema = "1.1.9"
 cw-multi-test = "0.16.2"
-tg-bindings-test = { version = "0.17.0", path = "../../packages/bindings-test" }
+tg-bindings-test = { version = "0.17.1", path = "../../packages/bindings-test" }

--- a/packages/bindings-test/Cargo.toml
+++ b/packages/bindings-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings-test"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Multitest (and other test helpers) support for Tgrade-specific contracts"
@@ -15,5 +15,5 @@ cw-multi-test = "0.16.2"
 cw-storage-plus = "1.0.1"
 schemars = "0.8"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.17.0", path = "../bindings" }
+tg-bindings = { version = "0.17.1", path = "../bindings" }
 thiserror = "1.0.21"

--- a/packages/bindings/Cargo.toml
+++ b/packages/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-bindings"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Bindings for CustomMsg and CustomQuery for the Tgrade blockchain"

--- a/packages/test-utils/Cargo.toml
+++ b/packages/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-test-utils"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Jakub Bogucki <jakub@confio.gmbh>"]
 edition = "2018"
 description = "Utilities used in contract tests"
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 cosmwasm-std = "1.1.9"
-tg-voting-contract = { path = "../voting-contract", version = "0.17.0" }
+tg-voting-contract = { path = "../voting-contract", version = "0.17.1" }

--- a/packages/tg3/Cargo.toml
+++ b/packages/tg3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg3"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Tgrade-3 Interface: On-Chain MultiSig/Voting contracts"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 cosmwasm-std = "1.1.9"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { version = "0.17.0", path = "../../packages/bindings" }
-tg-utils = { version = "0.17.0", path = "../../packages/utils" }
+tg-bindings = { version = "0.17.1", path = "../../packages/bindings" }
+tg-utils = { version = "0.17.1", path = "../../packages/utils" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.9"

--- a/packages/tg4/Cargo.toml
+++ b/packages/tg4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg4"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade-4 Interface: Groups Members"
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 cosmwasm-std = "1.1.9"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg-bindings = { path = "../bindings", version = "0.17.0" }
+tg-bindings = { path = "../bindings", version = "0.17.1" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.1.9"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-utils"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Tgrade Utils: helpers for various contracts"
@@ -19,6 +19,6 @@ cw2 = "1.0.0"
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-tg4 = { path = "../tg4", version = "0.17.0" }
-tg-bindings = { path = "../bindings", version = "0.17.0" }
+tg4 = { path = "../tg4", version = "0.17.1" }
+tg-bindings = { path = "../bindings", version = "0.17.1" }
 thiserror = "1.0.21"

--- a/packages/voting-contract/Cargo.toml
+++ b/packages/voting-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tg-voting-contract"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Bartłomiej Kuras <bart.k@confio.gmbh>"]
 edition = "2018"
 description = "Generic utils for building voting contracts for tgrade"
@@ -16,10 +16,10 @@ cw-utils = "1.0.1"
 cw-storage-plus = "1.0.1"
 schemars = "0.8.1"
 serde = { version = "1", default-features = false, features = ["derive"] }
-tg3 = { path = "../../packages/tg3", version = "0.17.0" }
-tg4 = { path = "../tg4", version = "0.17.0" }
-tg-bindings = { path = "../bindings", version = "0.17.0" }
-tg-utils = { version = "0.17.0", path = "../utils" }
+tg3 = { path = "../../packages/tg3", version = "0.17.1" }
+tg4 = { path = "../tg4", version = "0.17.1" }
+tg-bindings = { path = "../bindings", version = "0.17.1" }
+tg-utils = { version = "0.17.1", path = "../utils" }
 thiserror = "1"
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ anyhow = "1"
 cosmwasm-schema = "1.1.9"
 cw-multi-test = "0.16.2"
 derivative = "2"
-tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.0" }
-tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.17.0", features = ["library"] }
+tg-bindings-test = { path = "../../packages/bindings-test", version = "0.17.1" }
+tg4-engagement = { path = "../../contracts/tg4-engagement", version = "0.17.1", features = ["library"] }


### PR DESCRIPTION
Tried the `tg4-engagement` migration in the testnet, and AFAIK it worked as expected. Both mixer and distribution points were reduced after the migration.