### PR TITLE
Fix valset integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227315dc11f0bb22a273d0c43d3ba8ef52041c42cf959f09045388a89c57e661"
+checksum = "6a8263ce52392898aa17c2a0984b7c542df416e434f6e0cb1c1a11771054d159"
 dependencies = [
  "digest 0.10.5",
  "ed25519-zebra",
@@ -206,18 +206,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fca30d51f7e5fbfa6440d8b10d7df0231bdf77e97fd3fe5d0cb79cc4822e50c"
+checksum = "f1895f6d7a191bb044e3c555190d1da555c2571a3af41f849f60c855580e392f"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04135971e2c3b867eb793ca4e832543c077dbf72edaef7672699190f8fcdb619"
+checksum = "b1b99f612ccf162940ae2eef9f370ee37cf2ddcf4a9a8f5ee15ec6b46a5ecd2e"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c8f516a13ae481016aa35f0b5c4652459e8aee65b15b6fb51547a07cea5a0"
+checksum = "a92ceea61033cb69c336abf673da017ddf251fc4e26e0cdd387eaf8bedb14e49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d5a84d15cf7be17dc249a21588cdb0f7ef308907c50ce2723316a7d79c3dc"
+checksum = "ecc01051aab3bb88d5efe0b90f24a6df1ca96a873b12fc21b862b17539c84ee9"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -252,19 +252,23 @@ dependencies = [
  "schemars",
  "serde",
  "serde-json-wasm",
+ "sha2 0.10.6",
  "thiserror",
  "uint",
 ]
 
 [[package]]
 name = "cosmwasm-vm"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551db61c7aa685e7b0a97bc250dc7e930c7805951d3aadc190402e42de63123"
+checksum = "44edf20681c52ed522e52b30582692a66ea6790011da26e2856361f659e94d22"
 dependencies = [
+ "bitflags",
+ "bytecheck",
  "clru",
  "cosmwasm-crypto",
  "cosmwasm-std",
+ "enumset",
  "hex",
  "loupe",
  "parity-wasm",
@@ -1485,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
+checksum = "a15bee9b04dd165c3f4e142628982ddde884c2022a89e8ddf99c4829bf2c3a58"
 dependencies = [
  "serde",
 ]
@@ -1924,18 +1928,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/tgrade-validator-voting/src/validate.rs
+++ b/contracts/tgrade-validator-voting/src/validate.rs
@@ -210,7 +210,9 @@ mod tests {
                     addr: contract_addr,
                 })
             } else {
-                let mut res = ContractInfoResponse::new(1, "dummy_creator");
+                let mut res = ContractInfoResponse::default();
+                res.code_id = 1;
+                res.creator = "dummy_creator".into();
                 res.admin = self.contract_admin.clone();
                 let bin = to_binary(&res).unwrap();
                 SystemResult::Ok(ContractResult::Ok(bin))

--- a/contracts/tgrade-valset/.cargo/config
+++ b/contracts/tgrade-valset/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
-wasm-integration = "build --target wasm32-unknown-unknown"
+wasm-integration = "build --features integration --target wasm32-unknown-unknown"
 wasm-debug = "build --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 # requires wasm-integration built wasm

--- a/contracts/tgrade-valset/.cargo/config
+++ b/contracts/tgrade-valset/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
 wasm = "build --release --target wasm32-unknown-unknown"
-wasm-integration = "build --features integration --target wasm32-unknown-unknown"
+wasm-integration = "build --release --features integration --target wasm32-unknown-unknown"
 wasm-debug = "build --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 # requires wasm-integration built wasm

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -41,12 +41,12 @@ tg-utils = { version = "0.17.1", path = "../../packages/utils" }
 
 # For integration tests ("integration" feature)
 bech32 = { version = "0.8.1", optional = true }
-cosmwasm-vm = { version = "1.1.0", optional = true, default-features = false, features = ["iterator"] }
 
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1.5"
 cosmwasm-schema = "1.1.9"
+cosmwasm-vm = { version = "1.1.0", default-features = false, features = ["iterator"] }
 cw-multi-test = "0.16.2"
 derivative = "2"
 tg4-engagement = { path = "../tg4-engagement", version = "0.17.1" }

--- a/contracts/tgrade-valset/Cargo.toml
+++ b/contracts/tgrade-valset/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
-integration = ["bech32", "cosmwasm-vm"]
+integration = ["bech32"]
 
 [dependencies]
 cosmwasm-std = "1.1.9"

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -195,7 +195,7 @@ pub fn execute(
         }
         ExecuteMsg::Unjail { operator } => execute_unjail(deps, env, info, operator),
         ExecuteMsg::Slash { addr, portion } => execute_slash(deps, env, info, addr, portion),
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "integration")]
         ExecuteMsg::SimulateValidatorSet { validators } => {
             execute_simulate_validators(deps, info, validators)
         }
@@ -433,7 +433,7 @@ fn execute_slash<Q: CustomQuery>(
     Ok(resp)
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "integration")]
 fn execute_simulate_validators<Q: CustomQuery>(
     deps: DepsMut<Q>,
     _info: MessageInfo,

--- a/contracts/tgrade-valset/src/contract.rs
+++ b/contracts/tgrade-valset/src/contract.rs
@@ -63,6 +63,7 @@ pub fn instantiate(
     // verify the message and contract address are valid
     msg.validate()?;
     let membership = Tg4Contract(deps.api.addr_validate(&msg.membership)?);
+    #[cfg(not(feature = "integration"))]
     membership
         .total_points(&deps.querier)
         .map_err(|_| ContractError::InvalidTg4Contract {})?;

--- a/contracts/tgrade-valset/src/lib.rs
+++ b/contracts/tgrade-valset/src/lib.rs
@@ -5,4 +5,5 @@ pub mod msg;
 mod multitest;
 mod rewards;
 pub mod state;
-mod test_helpers;
+#[cfg(any(test, feature = "integration"))]
+pub mod test_helpers;

--- a/contracts/tgrade-valset/src/msg.rs
+++ b/contracts/tgrade-valset/src/msg.rs
@@ -209,7 +209,7 @@ pub enum ExecuteMsg {
 
     /// This will update the validator set with the passed list.
     /// Used for testing validators storage.
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "integration")]
     SimulateValidatorSet {
         validators: Vec<ValidatorInfo>,
     },

--- a/contracts/tgrade-valset/src/test_helpers.rs
+++ b/contracts/tgrade-valset/src/test_helpers.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(any(test, feature = "integration"))]
 use cosmwasm_std::{Addr, Binary};
 
 use tg_bindings::Pubkey;

--- a/contracts/tgrade-valset/tests/integration.rs
+++ b/contracts/tgrade-valset/tests/integration.rs
@@ -51,7 +51,7 @@ fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQu
 }
 
 static WASM: &[u8] =
-    include_bytes!("../../../target/wasm32-unknown-unknown/debug/tgrade_valset.wasm");
+    include_bytes!("../../../target/wasm32-unknown-unknown/release/tgrade_valset.wasm");
 
 const NUM_VALIDATORS: u32 = 956;
 const VALIDATOR_POWER: u64 = 1;

--- a/contracts/tgrade-valset/tests/integration.rs
+++ b/contracts/tgrade-valset/tests/integration.rs
@@ -5,13 +5,12 @@
 //!
 use bech32::{ToBase32, Variant};
 
-use cosmwasm_std::{to_binary, Addr, Binary, ContractResult, Empty, Response};
+use cosmwasm_std::{to_binary, Addr, ContractResult, Empty, Response};
 use cosmwasm_vm::testing::{
     execute, mock_env, mock_info, mock_instance_with_options, MockApi, MockInstanceOptions,
     MockQuerier, MockStorage,
 };
-use cosmwasm_vm::{features_from_csv, Instance};
-use tg_bindings::Pubkey;
+use cosmwasm_vm::{capabilities_from_csv, Instance};
 
 use tgrade_valset::msg::ExecuteMsg;
 use tgrade_valset::state::ValidatorInfo;
@@ -44,7 +43,7 @@ fn mock_instance_on_tgrade(wasm: &[u8]) -> Instance<MockApi, MockStorage, MockQu
     mock_instance_with_options(
         wasm,
         MockInstanceOptions {
-            supported_features: features_from_csv("iterator,tgrade"),
+            available_capabilities: capabilities_from_csv("iterator,tgrade"),
             gas_limit: 100_000_000_000_000,
             ..Default::default()
         },
@@ -60,7 +59,7 @@ const VALIDATOR_POWER: u64 = 1;
 #[test]
 fn test_validators_storage() {
     let mut deps = mock_instance_on_tgrade(WASM);
-    assert_eq!(deps.required_features().len(), 2);
+    assert_eq!(deps.required_capabilities().len(), 2);
 
     let info = mock_info("creator", &[]);
 


### PR DESCRIPTION
Update integration tests to cosmwasm-1.1.x.

~~Currently failing with `Region too big` runtime error. (See https://github.com/CosmWasm/cosmwasm/issues/1638)~~

To reproduce:
```
cargo wasm-debug
cargo test --test integration --features integration
```

**Update**: Solved by moving to a (feature-gated) wasm release build.